### PR TITLE
[bugfix] Only access face_to_cell information when it exists.

### DIFF
--- a/dune/grid/CpGrid.hpp
+++ b/dune/grid/CpGrid.hpp
@@ -692,7 +692,7 @@ namespace Dune
                 --size;
                 index=1;
             }
-            if(r[1].index()==std::numeric_limits<int>::max())
+            if(r.size()>1 && r[1].index()==std::numeric_limits<int>::max())
             {
                 assert(size==2);
                 --size;


### PR DESCRIPTION
Due to a missing a check it sometimes happened that information
about a second cell attached to the face accesses even though there
was only one cell there. This commit fixes this.