### PR TITLE
Adds access to the face tag

### DIFF
--- a/dune/grid/CpGrid.hpp
+++ b/dune/grid/CpGrid.hpp
@@ -864,6 +864,12 @@ namespace Dune
             return ret;
         }
 
+        /// \brief Get the cartesian tag associated with a face tag.
+        ///
+        /// The tag tells us in which direction the face would point
+        /// in the underlying cartesian grid.
+        /// \param An iterator that points to the face and was obtained
+        /// by iterating over Opm::UgGridHelpers::cell2Faces(grid).
         template<class Cell2FacesRowIterator>
         int
         faceTag(const Cell2FacesRowIterator& cell_face) const

--- a/dune/grid/CpGrid.hpp
+++ b/dune/grid/CpGrid.hpp
@@ -835,6 +835,11 @@ namespace Dune
         // Extra
         int boundaryId(int face) const
         {
+            // Note that this relies on the following implementation detail:
+            // The grid is always construct such that the faces where
+            // orientation() returns true are oriented along the positive IJK
+            // direction. Oriented means that the first cell attached to face
+            // has the lower index.
             int ret = 0;
             cpgrid::EntityRep<1> f(face, true);
             if (current_view_data_->face_to_cell_[f].size() == 1) {
@@ -876,6 +881,15 @@ namespace Dune
         int
         faceTag(const Cell2FacesRowIterator& cell_face) const
         {
+            // Note that this relies on the following implementation detail:
+            // The grid is always construct such that the interior faces constructed
+            // with orientation set to true are
+            // oriented along the positive IJK direction. Oriented means that
+            // the first cell attached to face has the lower index.
+            // For faces along the boundary (only one cell, always  attached at index 0)
+            // the orientation has to be determined by the orientation of the cell.
+            // If it is true then in UnstructuredGrid it would be stored at index 0,
+            // otherwise at index 1.
             const int cell = cell_face.getCellIndex();
             const int face = *cell_face;
             assert (0 <= cell);  assert (cell < numCells());

--- a/dune/grid/CpGrid.hpp
+++ b/dune/grid/CpGrid.hpp
@@ -15,7 +15,9 @@
 
 /*
   Copyright 2009, 2010 SINTEF ICT, Applied Mathematics.
-  Copyright 2009, 2010 Statoil ASA.
+  Copyright 2009, 2010, 2014 Statoil ASA.
+  Copyright 2014, 2015 Dr. Blatt - HPC-Simulartion-Software & Services
+  Copyright 2015       NTNU
 
   This file is part of The Open Porous Media project  (OPM).
 

--- a/dune/grid/CpGrid.hpp
+++ b/dune/grid/CpGrid.hpp
@@ -906,7 +906,7 @@ namespace Dune
                 //                    TOP  : BOTTOM
                 return normal_is_in ? 4    : 5; // min(K) : max(K)
             default:
-                OPM_THROW(std::runtime_error, "Unhandeled face tag. This should never happen!");
+                OPM_THROW(std::logic_error, "Unhandled face tag. This should never happen!");
             }
         }
 

--- a/dune/grid/CpGrid.hpp
+++ b/dune/grid/CpGrid.hpp
@@ -864,9 +864,12 @@ namespace Dune
             return ret;
         }
 
+        template<class Cell2FacesRowIterator>
         int
-        faceTag(const int cell, const int face) const
+        faceTag(const Cell2FacesRowIterator& cell_face) const
         {
+            const int cell = cell_face.getCellIndex();
+            const int face = *cell_face;
             assert (0 <= cell);  assert (cell < numCells());
             assert (0 <= face);  assert (face < numFaces());
 


### PR DESCRIPTION
When calculating transmissibilities we need to access the cartesian face tag (I-, I+, J-, J+, K-, K+). This is done by a new method faceTag that takes an iterator over the cell faces as its argument. It is used to deduce the cell and face index and then compute the value as proposed by Bard.

This PR is needed to implement similar functionality to OPM/opm-core#720 for CpGrid in opm-autodiff.
A PR for opm-autodiff follows closely.

Supersedes #120.