### PR TITLE
Provide access to the underlying parallel index set and remote indices.

### DIFF
--- a/dune/grid/CpGrid.hpp
+++ b/dune/grid/CpGrid.hpp
@@ -1014,6 +1014,24 @@ namespace Dune
         }
         //@}
 #endif
+
+#if HAVE_MPI && DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
+        /// \brief The type of the parallel index set
+        typedef cpgrid::CpGridData::ParallelIndexSet ParallelIndexSet;
+        /// \brief The type of the remote indices information
+        typedef cpgrid::CpGridData::RemoteIndices RemoteIndices;
+
+        ParallelIndexSet& getCellIndexSet()
+        {
+            return current_view_data_->cell_indexset_;
+        }
+
+        RemoteIndices& getCellRemoteIndices()
+        {
+            return current_view_data_->cell_remote_indices_;
+        }
+
+#endif
         
     private:
         /// Scatter a global grid to all processors.

--- a/dune/grid/cpgrid/CpGridData.cpp
+++ b/dune/grid/cpgrid/CpGridData.cpp
@@ -611,7 +611,7 @@ void CpGridData::distributeGlobalGrid(const CpGrid& grid,
     typedef RemoteIndexListModifier<RemoteIndices::ParallelIndexSet, RemoteIndices::Allocator,
                                     false> Modifier;
     typedef RemoteIndices::RemoteIndex RemoteIndex;
-    RemoteIndices cell_remote_indices(cell_indexset_, cell_indexset_, ccobj_);
+    cell_remote_indices_.setIndexSets(cell_indexset_, cell_indexset_, ccobj_);
 
 
     // Create a map of ListModifiers
@@ -619,7 +619,7 @@ void CpGridData::distributeGlobalGrid(const CpGrid& grid,
         std::map<int,Modifier> modifiers;
         for(CellCounter::NeighborIterator n=cell_counter.neighbors.begin(), end=cell_counter.neighbors.end();
             n != end; ++n)
-            modifiers.insert(std::make_pair(*n, cell_remote_indices.getModifier<false,false>(*n)));
+            modifiers.insert(std::make_pair(*n, cell_remote_indices_.getModifier<false,false>(*n)));
         // Insert remote indices. For each entry in the index set, see wether there are overlap occurences and add them.
         for(ParallelIndexSet::const_iterator i=cell_indexset_.begin(), end=cell_indexset_.end();
             i!=end; ++i)
@@ -654,7 +654,7 @@ void CpGridData::distributeGlobalGrid(const CpGrid& grid,
     else
     {
         // Force update of the sync counter in the remote indices.
-        cell_remote_indices.getModifier<false,false>(0);
+        cell_remote_indices_.getModifier<false,false>(0);
     }
 
     // We can identify existing cells with the help of the index set.
@@ -929,16 +929,16 @@ void CpGridData::distributeGlobalGrid(const CpGrid& grid,
 
     // Compute the interface information for cells
     get<InteriorBorder_All_Interface>(cell_interfaces_)
-        .build(cell_remote_indices, EnumItem<AttributeSet, AttributeSet::owner>(),
+        .build(cell_remote_indices_, EnumItem<AttributeSet, AttributeSet::owner>(),
                AllSet<AttributeSet>());
     get<Overlap_OverlapFront_Interface>(cell_interfaces_)
-        .build(cell_remote_indices, EnumItem<AttributeSet, AttributeSet::overlap>(),
+        .build(cell_remote_indices_, EnumItem<AttributeSet, AttributeSet::overlap>(),
                EnumItem<AttributeSet, AttributeSet::overlap>());
     get<Overlap_All_Interface>(cell_interfaces_)
-        .build(cell_remote_indices, EnumItem<AttributeSet, AttributeSet::overlap>(),
+        .build(cell_remote_indices_, EnumItem<AttributeSet, AttributeSet::overlap>(),
                                  AllSet<AttributeSet>());
     get<All_All_Interface>(cell_interfaces_)
-        .build(cell_remote_indices, AllSet<AttributeSet>(), AllSet<AttributeSet>());
+        .build(cell_remote_indices_, AllSet<AttributeSet>(), AllSet<AttributeSet>());
 
     // Now we use the all_all communication of the cells to compute which faces and points
     // are also present on other processes and with what attribute.

--- a/dune/grid/cpgrid/CpGridData.hpp
+++ b/dune/grid/cpgrid/CpGridData.hpp
@@ -53,6 +53,9 @@
 #else
 #include <dune/common/mpihelper.hh>
 #endif
+#ifdef HAVE_DUNE_ISTL
+#include <dune/istl/owneroverlapcopy.hh>
+#endif
 #include <array>
 #include <dune/common/tuples.hh>
 #include "OrientedEntityTable.hpp"
@@ -376,22 +379,27 @@ private:
     // Boundary information (optional).
     bool use_unique_boundary_ids_;
 
+#ifdef HAVE_DUNE_ISTL
+    typedef Dune::OwnerOverlapCopyAttributeSet::AttributeSet AttributeSet;
+#else
     /// \brief The type of the set of the attributes
     enum AttributeSet{owner, overlap};
+#endif
 
 #if HAVE_MPI && DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
+
     /// \brief The type of the parallel index set
-    typedef Dune::ParallelIndexSet<int,ParallelLocalIndex<AttributeSet> > ParallelIndexSet;
+    typedef Dune::ParallelIndexSet<int,ParallelLocalIndex<AttributeSet>,512> ParallelIndexSet;
 
     /// \brief The parallel index set of the cells.
     ParallelIndexSet cell_indexset_;
 
     /// \brief The type of the remote indices information
     typedef Dune::RemoteIndices<ParallelIndexSet> RemoteIndices;
-    /*
+    
     /// \brief The remote index information for the cells.
-    RemoteIndices cell_remote_indices;
-    */
+    RemoteIndices cell_remote_indices_;
+    
     /// \brief Communication interface for the cells.
     tuple<Interface,Interface,Interface,Interface,Interface> cell_interfaces_;
     /*


### PR DESCRIPTION
For this we now explicitly save the remote index information. This change
is needed to easily setup the parallel information needed by the dune-istl
solvers.