### PR TITLE
CpGrid: Use shared_ptr to store the grid views and allow shallow copies

### DIFF
--- a/dune/grid/CpGrid.hpp
+++ b/dune/grid/CpGrid.hpp
@@ -204,8 +204,6 @@ namespace Dune
 
 	/// Default constructor
 	CpGrid();
-
-        ~CpGrid();
  
         /// Initialize the grid from parameters.
 	void init(const Opm::parameter::ParameterGroup& param);
@@ -949,7 +947,7 @@ namespace Dune
 #if HAVE_MPI && DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
             if(!distributed_data_)
                 OPM_THROW(std::runtime_error, "Moving Data only allowed with a load balanced grid!");
-            distributed_data_->scatterData(handle, data_, distributed_data_);
+            distributed_data_->scatterData(handle, data_.get(), distributed_data_.get());
 #else
             // Suppress warnings for unused argument.
             (void) handle;
@@ -968,7 +966,7 @@ namespace Dune
 #if HAVE_MPI && DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
             if(!distributed_data_)
                 OPM_THROW(std::runtime_error, "Moving Data only allowed with a load balance grid!");
-            distributed_data_->gatherData(handle, data_, distributed_data_);
+            distributed_data_->gatherData(handle, data_.get(), distributed_data_.get());
 #else
             // Suppress warnings for unused argument.
             (void) handle;
@@ -978,13 +976,13 @@ namespace Dune
         /// \brief Switch to the global view.
         void switchToGlobalView()
         {
-            current_view_data_=data_;
+            current_view_data_=data_.get();
         }
         
         /// \brief Switch to the distributed view.
         void switchToDistributedView()
         {
-            current_view_data_=distributed_data_;
+            current_view_data_=distributed_data_.get();
         }
         //@}
 #if ! DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
@@ -1041,11 +1039,11 @@ namespace Dune
          * 
          * All the data of the grid is stored there and
          * calls are forwarded to it.*/
-        cpgrid::CpGridData *data_;
+        std::shared_ptr<cpgrid::CpGridData> data_;
         /** @brief A pointer to data of the current View. */
-        cpgrid::CpGridData *current_view_data_;
+        cpgrid::CpGridData* current_view_data_;
         /** @brief The data stored for the distributed grid. */
-        cpgrid::CpGridData * distributed_data_;
+        std::shared_ptr<cpgrid::CpGridData> distributed_data_;
     }; // end Class CpGrid
 
 

--- a/dune/grid/cpgrid/CpGrid.cpp
+++ b/dune/grid/cpgrid/CpGrid.cpp
@@ -50,16 +50,10 @@ namespace Dune
 {
 
     CpGrid::CpGrid()
-        : data_( new cpgrid::CpGridData(*this) ), current_view_data_(data_),
+        : data_( new cpgrid::CpGridData(*this)),
+          current_view_data_(data_.get()),
           distributed_data_()
     {}
-
-    CpGrid::~CpGrid()
-    {
-        delete data_;
-        if(distributed_data_)
-            delete distributed_data_;
-    }
 
     /// Initialize the grid.
     void CpGrid::init(const Opm::parameter::ParameterGroup& param)
@@ -131,10 +125,9 @@ bool CpGrid::scatterGrid()
     }
     if(my_num<cc.size())
     {
-        distributed_data_ = new cpgrid::CpGridData(new_comm);
-        distributed_data_->distributeGlobalGrid(*this,*this->current_view_data_, cell_part);
+        distributed_data_.reset(new cpgrid::CpGridData(new_comm));
     }
-    current_view_data_ = distributed_data_;
+    current_view_data_ = distributed_data_.get();
     return true;
 #else
     std::cerr << "CpGrid::scatterGrid() is non-trivial only with "


### PR DESCRIPTION
In sim_fibo_ad_cp we need to access the global and the distributed
view at once. This can be done most elegantly by making a shallow
copy of the CpGrid (both use the same pointers to the underlying views)
and switching the view there. Therefore this commit uses shared_ptr to
hold the global and distributed view. Thus we do not even need a destructor.