### PR TITLE
Allow for adding multiple overlap layers during loadbalance.

### DIFF
--- a/dune/grid/CpGrid.hpp
+++ b/dune/grid/CpGrid.hpp
@@ -560,8 +560,9 @@ namespace Dune
         // loadbalance is not part of the grid interface therefore we skip it.
 
         /// \brief Distributes this grid over the available nodes in a distributed machine
+        /// \param The number of layers of cells of the overlap region (default: 1).
         /// \warning May only be called once.
-        bool loadBalance(int overlapLayers=2)
+        bool loadBalance(int overlapLayers=1)
         {
             return scatterGrid(overlapLayers);
         }

--- a/dune/grid/CpGrid.hpp
+++ b/dune/grid/CpGrid.hpp
@@ -569,10 +569,12 @@ namespace Dune
         
         /// \brief Distributes this grid and data over the available nodes in a distributed machine.
         /// \param data A data handle describing how to distribute attached data.
+        /// \param overlapLayers The number of layers of overlap cells to be added
+        ///        (default: 1)
         /// \tparam DataHandle The type implementing DUNE's DataHandle interface.
         /// \warning May only be called once.
         template<class DataHandle>
-        bool loadBalance(DataHandle& data, int overlapLayers=2)
+        bool loadBalance(DataHandle& data, int overlapLayers=1)
         {
             bool ret = scatterGrid(overlapLayers);
             scatterData(data);

--- a/dune/grid/CpGrid.hpp
+++ b/dune/grid/CpGrid.hpp
@@ -561,9 +561,9 @@ namespace Dune
 
         /// \brief Distributes this grid over the available nodes in a distributed machine
         /// \warning May only be called once.
-        bool loadBalance()
+        bool loadBalance(int overlapLayers=2)
         {
-            return scatterGrid();
+            return scatterGrid(overlapLayers);
         }
         
         /// \brief Distributes this grid and data over the available nodes in a distributed machine.
@@ -571,9 +571,9 @@ namespace Dune
         /// \tparam DataHandle The type implementing DUNE's DataHandle interface.
         /// \warning May only be called once.
         template<class DataHandle>
-        bool loadBalance(DataHandle& data)
+        bool loadBalance(DataHandle& data, int overlapLayers=2)
         {
-            bool ret = scatterGrid();
+            bool ret = scatterGrid(overlapLayers);
             scatterData(data);
             return ret;
         }
@@ -1033,7 +1033,7 @@ namespace Dune
         
     private:
         /// Scatter a global grid to all processors.
-        bool scatterGrid();
+        bool scatterGrid(int overlapLayers);
         
         /** @brief The data stored in the grid. 
          * 

--- a/dune/grid/common/GridPartitioning.hpp
+++ b/dune/grid/common/GridPartitioning.hpp
@@ -79,7 +79,7 @@ namespace Dune
      void addOverlapLayer(const CpGrid& grid,
                           const std::vector<int>& cell_part,
                           std::vector<std::set<int> >& cell_overlap,
-                          int mypart, bool all=false);
+                          int mypart, int overlapLayers, bool all=false);
 
 } // namespace Dune
 

--- a/dune/grid/cpgrid/CpGrid.cpp
+++ b/dune/grid/cpgrid/CpGrid.cpp
@@ -84,7 +84,7 @@ namespace Dune
     }
 
 
-bool CpGrid::scatterGrid()
+bool CpGrid::scatterGrid(int overlapLayers)
 {
 #if HAVE_MPI && DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
     if(distributed_data_)
@@ -126,6 +126,8 @@ bool CpGrid::scatterGrid()
     if(my_num<cc.size())
     {
         distributed_data_.reset(new cpgrid::CpGridData(new_comm));
+        distributed_data_->distributeGlobalGrid(*this,*this->current_view_data_, cell_part,
+                                                overlapLayers);
     }
     current_view_data_ = distributed_data_.get();
     return true;

--- a/dune/grid/cpgrid/CpGridData.cpp
+++ b/dune/grid/cpgrid/CpGridData.cpp
@@ -515,7 +515,8 @@ void createInterfaces(std::vector<std::map<int,char> >& attributes,
 
 void CpGridData::distributeGlobalGrid(const CpGrid& grid,
                                       const CpGridData& view_data,
-                                      const std::vector<int>& cell_part)
+                                      const std::vector<int>& cell_part,
+                                      int overlap_layers)
 {
 #if HAVE_MPI && DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
     Dune::CollectiveCommunication<Dune::MPIHelper::MPICommunicator>& ccobj=ccobj_;
@@ -531,7 +532,7 @@ void CpGridData::distributeGlobalGrid(const CpGrid& grid,
     std::vector<std::set<int> > overlap; 
     
     overlap.resize(cell_part.size());
-    addOverlapLayer(grid, cell_part, overlap, my_rank, false);
+    addOverlapLayer(grid, cell_part, overlap, my_rank, false, overlap_layers);
     // count number of cells
     struct CellCounter
     {

--- a/dune/grid/cpgrid/CpGridData.hpp
+++ b/dune/grid/cpgrid/CpGridData.hpp
@@ -238,7 +238,8 @@ public:
     /// The whole grid must be available on all processors.
     void distributeGlobalGrid(const CpGrid& grid,
                               const CpGridData& view_data,
-                              const std::vector<int>& cell_part);
+                              const std::vector<int>& cell_part,
+                              int overlap_layers);
 
     /// \brief communicate objects for all codims on a given level
     /// \param data The data handle describing the data. Has to adhere to the


### PR DESCRIPTION
Surpsingly an overlap layer of one cell does not seem to be
sufficient for opm-autodiff. Therefore with this commit we allow
multiple overlap layers and use 2 as the safe default.