### PR TITLE
Suppress warnings

### DIFF
--- a/dune/grid/CpGrid.hpp
+++ b/dune/grid/CpGrid.hpp
@@ -43,9 +43,14 @@
 #include <array>
 #include <opm/core/utility/ErrorMacros.hpp>
 
+// Warning suppression for Dune includes.
+#include <opm/core/utility/platform_dependent/disable_warnings.h>
+
 #include <dune/grid/common/capabilities.hh>
 #include <dune/grid/common/grid.hh>
 #include <dune/grid/common/gridenums.hh>
+
+#include <opm/core/utility/platform_dependent/reenable_warnings.h>
 
 #include "cpgrid/Intersection.hpp"
 #include "cpgrid/Entity.hpp"

--- a/dune/grid/common/GridPartitioning.cpp
+++ b/dune/grid/common/GridPartitioning.cpp
@@ -244,11 +244,12 @@ void addOverlapCornerCell(const CpGrid& grid, int owner,
     const CpGrid::LeafIndexSet& ix = grid.leafIndexSet();
     int my_index = ix.index(from);
     int nb_index = ix.index(neighbor);
-
-    for ( int i=0; i< from.subEntities(CpGrid::dimension); i++ )
+    const int num_from_subs = from.subEntities(CpGrid::dimension);
+    for ( int i = 0; i < num_from_subs ; i++ )
     {
         int mypoint = ix.index(*from.subEntity<CpGrid::dimension>(i));
-        for ( int j=0; j<neighbor.subEntities(CpGrid::dimension); j++)
+        const int num_nb_subs = neighbor.subEntities(CpGrid::dimension);
+        for ( int j = 0; j < num_nb_subs; j++)
         {
             int otherpoint = ix.index(*neighbor.subEntity<CpGrid::dimension>(i));
             if ( mypoint == otherpoint )

--- a/dune/grid/common/Volumes.hpp
+++ b/dune/grid/common/Volumes.hpp
@@ -37,6 +37,9 @@
 
 #include <numeric>
 
+// Warning suppression for Dune includes.
+#include <opm/core/utility/platform_dependent/disable_warnings.h>
+
 #include <dune/common/version.hh>
 #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 3)
 #include <dune/common/math.hh>
@@ -44,6 +47,8 @@
 #include <dune/common/misc.hh>
 #endif
 #include <dune/common/fvector.hh>
+
+#include <opm/core/utility/platform_dependent/reenable_warnings.h>
 
 namespace Dune
 {

--- a/dune/grid/cpgrid/CpGrid.cpp
+++ b/dune/grid/cpgrid/CpGrid.cpp
@@ -131,7 +131,8 @@ bool CpGrid::scatterGrid(int overlapLayers)
     }
     current_view_data_ = distributed_data_.get();
     return true;
-#else
+#else // #if HAVE_MPI && DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
+    static_cast<void>(overlapLayers);
     std::cerr << "CpGrid::scatterGrid() is non-trivial only with "
               << "MPI support and if the target Dune platform is "
               << "sufficiently recent.\n";

--- a/dune/grid/cpgrid/CpGridData.cpp
+++ b/dune/grid/cpgrid/CpGridData.cpp
@@ -8,10 +8,16 @@
 #include"OrientedEntityTable.hpp"
 #include"Indexsets.hpp"
 #include"PartitionTypeIndicator.hpp"
+
+// Warning suppression for Dune includes.
+#include <opm/core/utility/platform_dependent/disable_warnings.h>
+
 #include <dune/grid/common/GridPartitioning.hpp>
 #include <dune/common/parallel/remoteindices.hh>
 #include <dune/common/enumset.hh>
 #include <opm/core/utility/SparseTable.hpp>
+
+#include <opm/core/utility/platform_dependent/reenable_warnings.h>
 
 namespace Dune
 {

--- a/dune/grid/cpgrid/CpGridData.cpp
+++ b/dune/grid/cpgrid/CpGridData.cpp
@@ -517,7 +517,8 @@ void createInterfaces(std::vector<std::map<int,char> >& attributes,
                                 
 }
 
-#endif
+#endif // #if HAVE_MPI && DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
+
 
 void CpGridData::distributeGlobalGrid(const CpGrid& grid,
                                       const CpGridData& view_data,
@@ -533,7 +534,7 @@ void CpGridData::distributeGlobalGrid(const CpGrid& grid,
     for(Iterator i=cell_part.begin(); i!= cell_part.end(); ++i)
         if(*i>=size)
             OPM_THROW(std::runtime_error, "rank for cell is too big");
-#endif
+#endif // #ifdef DEBUG
     // vector with the set of ranks that
     std::vector<std::set<int> > overlap; 
     
@@ -971,10 +972,11 @@ void CpGridData::distributeGlobalGrid(const CpGrid& grid,
     comm.forward(point_handle);
     createInterfaces(point_attributes, partition_type_indicator_->point_indicator_.begin(),
                      point_interfaces_);
-#else
+#else // #if HAVE_MPI && DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
     static_cast<void>(grid);
     static_cast<void>(view_data);
     static_cast<void>(cell_part);
+    static_cast<void>(overlap_layers);
 #endif    
 }
 

--- a/dune/grid/cpgrid/CpGridData.hpp
+++ b/dune/grid/cpgrid/CpGridData.hpp
@@ -47,6 +47,9 @@
 #ifndef OPM_CPGRIDDATA_HEADER
 #define OPM_CPGRIDDATA_HEADER
 
+// Warning suppression for Dune includes.
+#include <opm/core/utility/platform_dependent/disable_warnings.h>
+
 #include <dune/common/version.hh>
 #if DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
 #include <dune/common/parallel/mpihelper.hh>
@@ -56,14 +59,6 @@
 #ifdef HAVE_DUNE_ISTL
 #include <dune/istl/owneroverlapcopy.hh>
 #endif
-#include <array>
-#include <dune/common/tuples.hh>
-#include "OrientedEntityTable.hpp"
-#include "DefaultGeometryPolicy.hpp"
-#include <opm/core/grid/cpgpreprocess/preprocess.h>
-
-#include <opm/parser/eclipse/Deck/Deck.hpp>
-#include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 
 #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 3)
 #include <dune/common/parallel/collectivecommunication.hh>
@@ -77,6 +72,17 @@
 #include <dune/common/parallel/variablesizecommunicator.hh>
 #endif
 #include <dune/grid/common/gridenums.hh>
+#include <dune/common/tuples.hh>
+
+#include <opm/core/utility/platform_dependent/reenable_warnings.h>
+
+
+#include <array>
+#include "OrientedEntityTable.hpp"
+#include "DefaultGeometryPolicy.hpp"
+#include <opm/core/grid/cpgpreprocess/preprocess.h>
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include "Entity2IndexDataHandle.hpp"
 #include "GlobalIdMapping.hpp"
 

--- a/dune/grid/cpgrid/EntityRep.hpp
+++ b/dune/grid/cpgrid/EntityRep.hpp
@@ -44,7 +44,11 @@
 //    within method Dune::SignedEntityVariable<T,codim>::operator[](),
 //    but Dune::FieldVector<K,n> does not provide such an operator.
 //
+
+// Warning suppression for Dune includes.
+#include <opm/core/utility/platform_dependent/disable_warnings.h>
 #include <dune/common/fvector.hh>
+#include <opm/core/utility/platform_dependent/reenable_warnings.h>
 
 namespace Dune
 {

--- a/dune/grid/cpgrid/Geometry.hpp
+++ b/dune/grid/cpgrid/Geometry.hpp
@@ -36,10 +36,16 @@
 #ifndef OPM_GEOMETRY_HEADER
 #define OPM_GEOMETRY_HEADER
 
+// Warning suppression for Dune includes.
+#include <opm/core/utility/platform_dependent/disable_warnings.h>
+
 #include <dune/common/version.hh>
 #include <dune/geometry/referenceelements.hh>
 #include <dune/geometry/genericgeometry/geometrytraits.hh>
 #include <dune/geometry/genericgeometry/matrixhelper.hh>
+
+#include <opm/core/utility/platform_dependent/reenable_warnings.h>
+
 #include <opm/core/utility/ErrorMacros.hpp>
 
 namespace Dune

--- a/dune/grid/cpgrid/Geometry.hpp
+++ b/dune/grid/cpgrid/Geometry.hpp
@@ -509,6 +509,7 @@ namespace Dune
             /// Returns the single corner: the vertex itself.
 	    GlobalCoordinate corner(int cor) const
 	    {
+                static_cast<void>(cor);
                 assert(cor == 0);
                 return pos_;
 	    }

--- a/dune/grid/cpgrid/readEclipseFormat.cpp
+++ b/dune/grid/cpgrid/readEclipseFormat.cpp
@@ -69,7 +69,7 @@ namespace Dune
 			       std::vector<int>& new_actnum,
 			       grdecl& output);
 	void removeOuterCellLayer(processed_grid& grid);
-	void removeUnusedNodes(processed_grid& grid);
+	// void removeUnusedNodes(processed_grid& grid); // NOTE: not deleted, see comment at definition.
 	void buildTopo(const processed_grid& output,
 		       std::vector<int>& global_cell,
 		       cpgrid::OrientedEntityTable<0, 1>& c2f,
@@ -513,6 +513,11 @@ namespace cpgrid
 
 
 
+        /*
+
+        // NOTE: This function has been commented out as it is not in use, and therefore
+        //       generates warnings. It has not been deleted, as it should eventually be
+        //       used, what is missing is thorough testing of the method.
 
 	void removeUnusedNodes(processed_grid& grid)
 	{
@@ -572,7 +577,7 @@ namespace cpgrid
             //   3. Set grid.number_of_nodes.
             grid.number_of_nodes = nodecount;
 	}
-
+        */
 
 
 

--- a/examples/finitevolume/finitevolume.cc
+++ b/examples/finitevolume/finitevolume.cc
@@ -2,6 +2,11 @@
 #include <iostream>               // for input/output to shell
 #include <fstream>                // for input/output to files
 #include <vector>                 // STL vector class
+
+
+// Warning suppression for Dune includes.
+#include <opm/core/utility/platform_dependent/disable_warnings.h>
+
 #include <dune/grid/common/mcmgmapper.hh> // mapper class
 
 #include <dune/common/version.hh>
@@ -13,6 +18,8 @@
 
 // checks for defined gridtype and inlcudes appropriate dgfparser implementation
 //#include <dune/grid/io/file/dgfparser/dgfgridtype.hh>
+
+#include <opm/core/utility/platform_dependent/reenable_warnings.h>
 
 #include "vtkout.hh"
 // #include"transportproblem2.hh"

--- a/examples/finitevolume/vtkout.hh
+++ b/examples/finitevolume/vtkout.hh
@@ -1,4 +1,8 @@
+// Warning suppression for Dune includes.
+#include <opm/core/utility/platform_dependent/disable_warnings.h>
 #include <dune/grid/io/file/vtk/vtkwriter.hh>
+#include <opm/core/utility/platform_dependent/reenable_warnings.h>
+
 #include <stdio.h>
 
 template<class G, class V>

--- a/examples/grdecl2vtu.cpp
+++ b/examples/grdecl2vtu.cpp
@@ -23,7 +23,12 @@
 #endif
 
 #include <iostream>
+
+// Warning suppression for Dune includes.
+#include <opm/core/utility/platform_dependent/disable_warnings.h>
 #include <dune/grid/io/file/vtk/vtkwriter.hh>
+#include <opm/core/utility/platform_dependent/reenable_warnings.h>
+
 #include <dune/grid/CpGrid.hpp>
 #include <opm/core/io/eclipse/EclipseGridInspector.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>

--- a/tests/cpgrid/distribution_test.cpp
+++ b/tests/cpgrid/distribution_test.cpp
@@ -7,6 +7,11 @@
 #include <boost/test/unit_test.hpp>
 
 #include <dune/grid/CpGrid.hpp>
+
+
+// Warning suppression for Dune includes.
+#include <opm/core/utility/platform_dependent/disable_warnings.h>
+
 #include <dune/geometry/referenceelements.hh>
 #include <dune/common/fvector.hh>
 #if HAVE_DUNE_GRID_CHECKS
@@ -16,6 +21,9 @@
 #include <dune/grid/test/checkpartition.cc>
 #include <dune/grid/test/checkcommunicate.cc>
 #endif
+
+#include <opm/core/utility/platform_dependent/reenable_warnings.h>
+
 
 #if HAVE_MPI
 class MPIError {


### PR DESCRIPTION
This removes lots of warnings when compiling the module, in particular warnings from Dune includes.
There should be no API or behaviour changes.