### PR TITLE
Moves all functions that do not depend on Eigen to Opm::UgGridHelpers. [2/3]

### DIFF
--- a/dune/grid/cpgrid/GridHelpers.cpp
+++ b/dune/grid/cpgrid/GridHelpers.cpp
@@ -78,6 +78,26 @@ beginFaceCentroids(const Dune::CpGrid& grid)
     return FaceCentroidTraits<Dune::CpGrid>::IteratorType(grid, 0);
 }
 
+const double* cellCentroid(const Dune::CpGrid& grid, int cell_index)
+{
+    return &(grid.cellCentroid(cell_index)[0]);
+}
+
+double cellVolume(const  Dune::CpGrid& grid, int cell_index)
+{
+    return grid.cellVolume(cell_index);
+}
+
+CellVolumeIterator beginCellVolumes(const Dune::CpGrid& grid)
+{
+    return CellVolumeIterator(grid, 0);
+}
+
+CellVolumeIterator endCellVolumes(const Dune::CpGrid& grid)
+{
+    return CellVolumeIterator(grid, numCells(grid));
+}
+
 FaceCentroidTraits<Dune::CpGrid>::ValueType
 faceCentroid(const Dune::CpGrid& grid, int face_index)
 {

--- a/dune/grid/cpgrid/GridHelpers.cpp
+++ b/dune/grid/cpgrid/GridHelpers.cpp
@@ -98,7 +98,7 @@ CellVolumeIterator endCellVolumes(const Dune::CpGrid& grid)
     return CellVolumeIterator(grid, numCells(grid));
 }
 
-FaceCentroidTraits<Dune::CpGrid>::ValueType
+const FaceCentroidTraits<Dune::CpGrid>::ValueType&
 faceCentroid(const Dune::CpGrid& grid, int face_index)
 {
     return grid.faceCentroid(face_index);

--- a/dune/grid/cpgrid/GridHelpers.hpp
+++ b/dune/grid/cpgrid/GridHelpers.hpp
@@ -27,6 +27,7 @@
 #include <opm/core/utility/platform_dependent/disable_warnings.h>
 
 #include <dune/grid/CpGrid.hpp>
+#include <dune/common/iteratorfacades.hh>
 
 #include <opm/core/utility/platform_dependent/reenable_warnings.h>
 

--- a/dune/grid/cpgrid/GridHelpers.hpp
+++ b/dune/grid/cpgrid/GridHelpers.hpp
@@ -456,7 +456,7 @@ private:
 };
 
 template<>
-struct ADCellVolumesTraits<Dune::CpGrid>
+struct CellVolumeIteratorTraits<Dune::CpGrid>
 {
     typedef CellVolumeIterator IteratorType;
 };

--- a/dune/grid/cpgrid/GridHelpers.hpp
+++ b/dune/grid/cpgrid/GridHelpers.hpp
@@ -399,6 +399,74 @@ beginCellCentroids(const Dune::CpGrid& grid);
 double cellCentroidCoordinate(const Dune::CpGrid& grid, int cell_index,
                               int coordinate);
 
+/// \brief Get the centroid of a cell.
+/// \param grid The grid whose cell centroid we query.
+/// \param cell_index The index of the corresponding cell.
+const double* cellCentroid(const Dune::CpGrid& grid, int cell_index);
+
+/// \brief Get the volume of a cell.
+/// \param grid The grid the cell belongs to.
+/// \param cell_index The index of the cell.
+double cellVolume(const  Dune::CpGrid& grid, int cell_index);
+
+/// \brief An iterator over the cell volumes.
+class CellVolumeIterator
+    : public Dune::RandomAccessIteratorFacade<CellVolumeIterator, double, double, int>
+{
+public:
+    /// \brief Creates an iterator.
+    /// \param grid The grid the iterator belongs to.
+    /// \param cell_index The position of the iterator.
+    CellVolumeIterator(const  Dune::CpGrid& grid, int cell_index)
+        : grid_(&grid), cell_index_(cell_index)
+    {}
+
+    double dereference() const
+    {
+        return grid_->cellVolume(cell_index_);
+    }
+    void increment()
+    {
+        ++cell_index_;
+    }
+    double elementAt(int n) const
+    {
+        return grid_->cellVolume(n);
+    }
+    void advance(int n)
+    {
+        cell_index_+=n;
+    }
+    void decrement()
+    {
+        --cell_index_;
+    }
+    int distanceTo(const CellVolumeIterator& o) const
+    {
+        return o.cell_index_-cell_index_;
+    }
+    bool equals(const CellVolumeIterator& o) const
+    {
+        return o.grid_==grid_ && o.cell_index_==cell_index_;
+    }
+
+private:
+    const Dune::CpGrid* grid_;
+    int cell_index_;
+};
+
+template<>
+struct ADCellVolumesTraits<Dune::CpGrid>
+{
+    typedef CellVolumeIterator IteratorType;
+};
+
+/// \brief Get an iterator over the cell volumes of a grid positioned at the first cell.
+CellVolumeIterator beginCellVolumes(const Dune::CpGrid& grid);
+
+/// \brief Get an iterator over the cell volumes of a grid positioned one after the last cell.
+CellVolumeIterator endCellVolumes(const Dune::CpGrid& grid);
+
 template<>
 struct FaceCentroidTraits<Dune::CpGrid>
 {

--- a/dune/grid/cpgrid/GridHelpers.hpp
+++ b/dune/grid/cpgrid/GridHelpers.hpp
@@ -482,7 +482,7 @@ beginFaceCentroids(const Dune::CpGrid& grid);
 /// \param grid The grid.
 /// \param face_index The index of the specific face.
 /// \param coordinate The coordinate index.
-FaceCentroidTraits<Dune::CpGrid>::ValueType
+const FaceCentroidTraits<Dune::CpGrid>::ValueType&
 faceCentroid(const Dune::CpGrid& grid, int face_index);
 
 template<>


### PR DESCRIPTION
This PR moves all the grid helper functions that do not depend on Eigen to the module where the
grid is declared and implement.

This is the first out of three PRs that should be merged simultaneously. The irst one is OPM/opm-core#764.