### PR TITLE
add EntityPointer::Reference typedef

### DIFF
--- a/dune/grid/cpgrid/Entity.hpp
+++ b/dune/grid/cpgrid/Entity.hpp
@@ -282,6 +282,7 @@ namespace Dune
         {
         public:
             typedef cpgrid::Entity<codim> Entity;
+            typedef const Entity& Reference;
 
             /// Construction from entity.
             explicit EntityPointer(const Entity& e)


### PR DESCRIPTION
this seems to be required by the VtkWriter class in recent versions of
the Dune master branch (soon to be Dune 2.4).