### PR TITLE
[bugfix] Use resize to change the size of cell_to_point_.

### DIFF
--- a/dune/grid/cpgrid/CpGridData.cpp
+++ b/dune/grid/cpgrid/CpGridData.cpp
@@ -795,7 +795,7 @@ void CpGridData::distributeGlobalGrid(const CpGrid& grid,
     // Construct the sparse matrix like data structure.
     //OrientedEntityTable<0, 1> cell_to_face;
     cell_to_face_.reserve(cell_indexset_.size(), data_size);
-    cell_to_point_.reserve(cell_indexset_.size());
+    cell_to_point_.resize(cell_indexset_.size());
 
     for(auto i=cell_indexset_.begin(), end=cell_indexset_.end();
         i!=end; ++i)


### PR DESCRIPTION
Previously we just used reserve, but never actually changed the
size. Nevertheless we used operater[] to set and get values up to index
of the reserved size-1. Semantically this is a bug that fortunately
never results in a memory problem. Nevertheless g++ detects this
problem whith -D_GLIBCXX_DEBUG and aborts.

With this commit we now use resize() to change the size. This should definitely
go into the release.