### PR TITLE
fixed: doxy for dune-cornerpoint

### DIFF
--- a/cmake/Modules/OpmDoc.cmake
+++ b/cmake/Modules/OpmDoc.cmake
@@ -24,7 +24,7 @@ macro (opm_doc opm doxy_dir)
   file (MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/${doxy_dir})
   file (WRITE ${PROJECT_BINARY_DIR}/${doxy_dir}/Doxyfile.in ${_doxy_templ} ${_doxy_local})
   # set this generically named variable so even the custom file can be shared
-  set (src_DIR "${${opm}_DIR}")
+  set (src_DIR "dune")
   # replace variables in this combined file
   configure_file (
 	${PROJECT_BINARY_DIR}/${doxy_dir}/Doxyfile.in


### PR DESCRIPTION
source dir cannot be derived from the opm project file.
this is a hotfix, a better solution should be put in master.