### PR TITLE
Adds support for initial loadbalancing using ZOLTAN

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -40,6 +40,7 @@ list (APPEND MAIN_SOURCE_FILES
 	dune/grid/common/GeometryHelpers.cpp
 	dune/grid/common/GridPartitioning.cpp
 	dune/grid/common/ZoltanGraphFunctions.cpp
+	dune/grid/common/ZoltanPartition.cpp
 	)
 
 # originally generated with the command:
@@ -108,4 +109,5 @@ list (APPEND PUBLIC_HEADER_FILES
 	dune/grid/cpgrid/PartitionTypeIndicator.hpp
 	dune/grid/cpgrid/PersistentContainer.hpp
 	dune/grid/common/ZoltanGridFunctions.hpp
+	dune/grid/common/ZoltanPartition.hpp
 	)

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -39,6 +39,7 @@ list (APPEND MAIN_SOURCE_FILES
 	dune/grid/cpgrid/writeSintefLegacyFormat.cpp
 	dune/grid/common/GeometryHelpers.cpp
 	dune/grid/common/GridPartitioning.cpp
+	dune/grid/common/ZoltanGraphFunctions.cpp
 	)
 
 # originally generated with the command:
@@ -61,6 +62,7 @@ list (APPEND TEST_SOURCE_FILES
 	tests/cpgrid/geometry_test.cpp
 	tests/cpgrid/orientedentitytable_test.cpp
 	tests/cpgrid/partition_iterator_test.cpp
+	tests/cpgrid/zoltan_test.cpp
 	)
 
 # originally generated with the command:
@@ -105,4 +107,5 @@ list (APPEND PUBLIC_HEADER_FILES
 	dune/grid/cpgrid/PartitionIteratorRule.hpp
 	dune/grid/cpgrid/PartitionTypeIndicator.hpp
 	dune/grid/cpgrid/PersistentContainer.hpp
+	dune/grid/common/ZoltanGridFunctions.hpp
 	)

--- a/dune/grid/common/ZoltanGraphFunctions.cpp
+++ b/dune/grid/common/ZoltanGraphFunctions.cpp
@@ -23,7 +23,7 @@
 #endif
 #include <dune/grid/common/ZoltanGraphFunctions.hpp>
 #include <dune/common/parallel/indexset.hh>
-#ifdef HAVE_ZOLTAN
+#if defined(HAVE_ZOLTAN) && defined(HAVE_MPI)
 namespace Dune
 {
 namespace cpgrid

--- a/dune/grid/common/ZoltanGraphFunctions.cpp
+++ b/dune/grid/common/ZoltanGraphFunctions.cpp
@@ -1,0 +1,159 @@
+/*
+  Copyright 2015 Dr. Blatt - HPC-Simulation-Software & Services.
+  Copyright 2015 NTNU
+
+  This file is part of The Open Porous Media project  (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include <config.h>
+#include <dune/grid/common/ZoltanGraphFunctions.hpp>
+#ifdef HAVE_ZOLTAN
+namespace Dune
+{
+namespace cpgrid
+{
+void getCpGridVertexList(void* cpGridPointer, int numGlobalIdEntries,
+                         int numLocalIdEntries, ZOLTAN_ID_PTR gids,
+                         ZOLTAN_ID_PTR lids, int wgtDim,
+                         float *objWgts, int *err)
+{
+    (void) wgtDim; (void) objWgts;
+    const Dune::CpGrid&  grid = *static_cast<const Dune::CpGrid*>(cpGridPointer);
+    auto& globalIdSet         =  grid.globalIdSet();
+    auto& localIdSet          =  grid.localIdSet();
+
+    if ( numGlobalIdEntries != numLocalIdEntries || numGlobalIdEntries != 1 )
+    {
+        std::cerr<<"numGlobalIdEntries="<<numGlobalIdEntries<<" numLocalIdEntries="<<numLocalIdEntries<<" grid cells="
+                 <<grid.numCells()<<std::endl;
+        *err = ZOLTAN_FATAL;
+        return;
+    }
+    int idx = 0;
+    for (auto cell = grid.leafbegin<0>(), cellEnd = grid.leafend<0>();
+         cell != cellEnd; ++cell)
+    {
+        gids[idx]   = globalIdSet.id(*cell);
+        lids[idx++] = localIdSet.id(*cell);
+    }
+    *err = ZOLTAN_OK;
+}
+
+void getCpGridNumEdgesList(void *cpGridPointer, int sizeGID, int sizeLID,
+                           int numCells,
+                           ZOLTAN_ID_PTR globalID, ZOLTAN_ID_PTR localID,
+                           int *numEdges, int *err)
+{
+    (void) globalID;
+    const Dune::CpGrid&  grid = *static_cast<const Dune::CpGrid*>(cpGridPointer);
+    if ( sizeGID != 1 || sizeLID != 1 || numCells != grid.numCells() )
+    {
+        *err = ZOLTAN_FATAL;
+        return;
+    }
+    for( int i = 0; i < numCells;  i++ )
+    {
+        // For the graph there is an edge only if the face has two neighbors.
+        // Therefore we need to check each face
+        int edges = 0;
+        int lid   = localID[i];
+        for ( int local_face = 0; local_face < grid.numCellFaces(static_cast<int>(localID[i])); ++local_face )
+        {
+            const int face = grid.cellFace(lid, local_face);
+            if ( grid.faceCell(face, 0) != -1 && grid.faceCell(face, 1) != -1 )
+            {
+                ++edges;
+            }
+        }
+        numEdges[i] = edges;
+    }
+    std::cout<<std::endl;
+    *err = ZOLTAN_OK;
+}
+
+void getCpGridEdgeList(void *cpGridPointer, int sizeGID, int sizeLID,
+                       int numCells, ZOLTAN_ID_PTR globalID, ZOLTAN_ID_PTR localID,
+                       int *numEdges,
+                       ZOLTAN_ID_PTR nborGID, int *nborProc,
+                       int wgtDim, float *ewgts, int *err)
+{
+    (void) wgtDim; (void) globalID; (void) numEdges; (void) ewgts;
+    const Dune::CpGrid&  grid = *static_cast<const Dune::CpGrid*>(cpGridPointer);
+    if ( sizeGID != 1 || sizeLID != 1 || numCells != grid.numCells() )
+    {
+        *err = ZOLTAN_FATAL;
+        return;
+    }
+    int oldidx = 0;
+    int idx = 0;
+
+    for( int cell = 0; cell < numCells;  cell++ )
+    {
+        const int currentCell = localID[cell];
+        for ( int local_face = 0 ; local_face < grid.numCellFaces(static_cast<int>(localID[cell])); ++local_face )
+        {
+            const int face  = grid.cellFace(currentCell, local_face);
+            int otherCell   = grid.faceCell(face, 0);
+            if ( otherCell == currentCell || otherCell == -1 )
+            {
+                otherCell = grid.faceCell(face, 1);
+                if ( otherCell == currentCell || otherCell == -1 )
+                {
+                    continue;
+                }
+                else
+                {
+                    nborGID[idx++] = globalID[otherCell];
+                    continue;
+                }
+            }
+            nborGID[idx++] = globalID[otherCell];
+        }
+        assert(numEdges[cell] == idx - oldidx);
+        oldidx = idx;
+    }
+
+    const int myrank = grid.comm().rank();
+
+    for ( int i = 0; i < idx; ++i )
+    {
+        nborProc[i] = myrank;
+    }
+#ifdef DEBUG
+    // The above relies heavily on the grid not being distributed already.
+    // Therefore we check here that all cells are owned by us.
+    GlobalLookupIndexSet<Dune::CpGrid::ParallelIndexSet> globalIdxSet(getCellIndexSet(),
+                                                                      grid.numCells());
+    for ( int cell = 0; cell < numCells;  cell++ )
+    {
+        if ( globaIdxSet.pair(cell).second.attribute() !=
+             Dune::CpGrid::ParallelIndexSet::AttributeSet::owner )
+        {
+            *err = ZOLTAN_FATAL;
+        }
+    }
+#endif
+}
+
+void setCpGridZoltanGraphFunctions(Zoltan_Struct *zz, Dune::CpGrid& grid)
+{
+      Zoltan_Set_Num_Obj_Fn(zz, getCpGridNumCells, &grid);
+      Zoltan_Set_Obj_List_Fn(zz, getCpGridVertexList, &grid);
+      Zoltan_Set_Num_Edges_Multi_Fn(zz, getCpGridNumEdgesList, &grid);
+      Zoltan_Set_Edge_List_Multi_Fn(zz, getCpGridEdgeList, &grid);
+}
+} // end namespace cpgrid
+} // end namespace Dune
+#endif // HAVE_ZOLTAN

--- a/dune/grid/common/ZoltanGraphFunctions.hpp
+++ b/dune/grid/common/ZoltanGraphFunctions.hpp
@@ -1,6 +1,7 @@
 /*
   Copyright 2015 Dr. Blatt - HPC-Simulation-Software & Services.
   Copyright 2015 NTNU
+  Copyright 2015 Statoil AS
 
   This file is part of The Open Porous Media project  (OPM).
 
@@ -60,7 +61,31 @@ void getCpGridEdgeList(void *cpGridPointer, int sizeGID, int sizeLID,
                        ZOLTAN_ID_PTR nborGID, int *nborProc,
                        int wgt_dim, float *ewgts, int *err);
 
-void setCpGridZoltanGraphFunctions(Zoltan_Struct *zz, Dune::CpGrid& grid);
+void getNullVertexList(void* cpGridPointer, int numGlobalIds,
+                         int numLocalIds, ZOLTAN_ID_PTR gids,
+                         ZOLTAN_ID_PTR lids, int wgtDim,
+                         float *objWgts, int *err);
+
+void getNullNumEdgesList(void *cpGridPointer, int sizeGID, int sizeLID,
+                           int numCells,
+                           ZOLTAN_ID_PTR globalID, ZOLTAN_ID_PTR localID,
+                           int *numEdges, int *err);
+
+void getNullEdgeList(void *cpGridPointer, int sizeGID, int sizeLID,
+                       int numCells, ZOLTAN_ID_PTR globalID, ZOLTAN_ID_PTR localID,
+                       int *num_edges,
+                       ZOLTAN_ID_PTR nborGID, int *nborProc,
+                       int wgt_dim, float *ewgts, int *err);
+
+inline int getNullNumCells(void* cpGridPointer, int* err)
+{
+    (void) cpGridPointer;
+    *err = ZOLTAN_OK;
+    return 0;
+}
+
+void setCpGridZoltanGraphFunctions(Zoltan_Struct *zz, const Dune::CpGrid& grid,
+                                   bool pretendNull=false);
 } // end namespace cpgrid
 } // end namespace Dune
 

--- a/dune/grid/common/ZoltanGraphFunctions.hpp
+++ b/dune/grid/common/ZoltanGraphFunctions.hpp
@@ -23,10 +23,11 @@
 
 #include <dune/grid/CpGrid.hpp>
 
-#ifdef HAVE_ZOLTAN
+#if defined(HAVE_ZOLTAN) && defined(HAVE_MPI)
 
 #include <mpi.h>
-// Zoltan redefines HAVE_MPI. Therfore we need to back it up, undef, and
+
+// Zoltan redefines HAVE_MPI. Therefore we need to back it up, undef, and
 // redifine it after the header is included
 #undef HAVE_MPI
 #include <zoltan.h>

--- a/dune/grid/common/ZoltanGraphFunctions.hpp
+++ b/dune/grid/common/ZoltanGraphFunctions.hpp
@@ -37,7 +37,10 @@ namespace Dune
 {
 namespace cpgrid
 {
-
+/// \brief Get the number of cells of the grid.
+///
+/// The cells are the vertices of the graph.
+/// \return The number of vertices of the graph representing the grid.
 inline int getCpGridNumCells(void* cpGridPointer, int* err)
 {
     const Dune::CpGrid&  grid = *static_cast<const Dune::CpGrid*>(cpGridPointer);
@@ -45,38 +48,47 @@ inline int getCpGridNumCells(void* cpGridPointer, int* err)
     return grid.numCells();
 }
 
+/// \brief Get the list of vertices of the graph of the grid.
 void getCpGridVertexList(void* cpGridPointer, int numGlobalIds,
                          int numLocalIds, ZOLTAN_ID_PTR gids,
                          ZOLTAN_ID_PTR lids, int wgtDim,
                          float *objWgts, int *err);
 
+/// \brief Get the number of edges the graph of the grid.
 void getCpGridNumEdgesList(void *cpGridPointer, int sizeGID, int sizeLID,
                            int numCells,
                            ZOLTAN_ID_PTR globalID, ZOLTAN_ID_PTR localID,
                            int *numEdges, int *err);
 
+/// \brief Get the list of edges of the graph of the grid.
 void getCpGridEdgeList(void *cpGridPointer, int sizeGID, int sizeLID,
                        int numCells, ZOLTAN_ID_PTR globalID, ZOLTAN_ID_PTR localID,
                        int *num_edges,
                        ZOLTAN_ID_PTR nborGID, int *nborProc,
                        int wgt_dim, float *ewgts, int *err);
 
+/// \brief Get a list of vertices with zero enties
 void getNullVertexList(void* cpGridPointer, int numGlobalIds,
                          int numLocalIds, ZOLTAN_ID_PTR gids,
                          ZOLTAN_ID_PTR lids, int wgtDim,
                          float *objWgts, int *err);
 
+/// \brief Get zero as the number of edges the graph of the grid.
 void getNullNumEdgesList(void *cpGridPointer, int sizeGID, int sizeLID,
                            int numCells,
                            ZOLTAN_ID_PTR globalID, ZOLTAN_ID_PTR localID,
                            int *numEdges, int *err);
 
+/// \brief Get a list of edges of size zero.
 void getNullEdgeList(void *cpGridPointer, int sizeGID, int sizeLID,
                        int numCells, ZOLTAN_ID_PTR globalID, ZOLTAN_ID_PTR localID,
                        int *num_edges,
                        ZOLTAN_ID_PTR nborGID, int *nborProc,
                        int wgt_dim, float *ewgts, int *err);
 
+/// \brief Get always zero as the number of cells of the grid.
+///
+/// The cells are the vertices of the graph.
 inline int getNullNumCells(void* cpGridPointer, int* err)
 {
     (void) cpGridPointer;
@@ -84,6 +96,10 @@ inline int getNullNumCells(void* cpGridPointer, int* err)
     return 0;
 }
 
+/// \brief Sets up the call-back functions for ZOLTAN's graph partitioning.
+/// \param zz The struct with the information for ZOLTAN.
+/// \param grid The grid to partition.
+/// \param pretendNull If true, we will pretend that the grid has zero cells.
 void setCpGridZoltanGraphFunctions(Zoltan_Struct *zz, const Dune::CpGrid& grid,
                                    bool pretendNull=false);
 } // end namespace cpgrid

--- a/dune/grid/common/ZoltanGraphFunctions.hpp
+++ b/dune/grid/common/ZoltanGraphFunctions.hpp
@@ -1,0 +1,68 @@
+/*
+  Copyright 2015 Dr. Blatt - HPC-Simulation-Software & Services.
+  Copyright 2015 NTNU
+
+  This file is part of The Open Porous Media project  (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef DUNE_CPGRID_ZOLTAN_GRAPH_FUNCTIONS_HEADER
+#define DUNE_CPGRID_ZOLTAN_GRAPH_FUNCTIONS_HEADER
+
+#include <dune/grid/CpGrid.hpp>
+
+#ifdef HAVE_ZOLTAN
+
+#include <mpi.h>
+// Zoltan redefines HAVE_MPI. Therfore we need to back it up, undef, and
+// redifine it after the header is included
+#undef HAVE_MPI
+#include <zoltan.h>
+#undef HAVE_MPI
+#define HAVE_MPI 1
+
+namespace Dune
+{
+namespace cpgrid
+{
+
+inline int getCpGridNumCells(void* cpGridPointer, int* err)
+{
+    const Dune::CpGrid&  grid = *static_cast<const Dune::CpGrid*>(cpGridPointer);
+    *err = ZOLTAN_OK;
+    return grid.numCells();
+}
+
+void getCpGridVertexList(void* cpGridPointer, int numGlobalIds,
+                         int numLocalIds, ZOLTAN_ID_PTR gids,
+                         ZOLTAN_ID_PTR lids, int wgtDim,
+                         float *objWgts, int *err);
+
+void getCpGridNumEdgesList(void *cpGridPointer, int sizeGID, int sizeLID,
+                           int numCells,
+                           ZOLTAN_ID_PTR globalID, ZOLTAN_ID_PTR localID,
+                           int *numEdges, int *err);
+
+void getCpGridEdgeList(void *cpGridPointer, int sizeGID, int sizeLID,
+                       int numCells, ZOLTAN_ID_PTR globalID, ZOLTAN_ID_PTR localID,
+                       int *num_edges,
+                       ZOLTAN_ID_PTR nborGID, int *nborProc,
+                       int wgt_dim, float *ewgts, int *err);
+
+void setCpGridZoltanGraphFunctions(Zoltan_Struct *zz, Dune::CpGrid& grid);
+} // end namespace cpgrid
+} // end namespace Dune
+
+#endif // HAVE_ZOLTAN
+#endif // header guard

--- a/dune/grid/common/ZoltanPartition.cpp
+++ b/dune/grid/common/ZoltanPartition.cpp
@@ -1,0 +1,98 @@
+/*
+  Copyright 2015 Dr. Blatt - HPC-Simulation-Software & Services.
+  Copyright 2015 NTNU
+  Copyright 2015 Statoil AS
+
+  This file is part of The Open Porous Media project  (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+#include <dune/grid/common/ZoltanPartition.hpp>
+#ifdef HAVE_ZOLTAN
+namespace Dune
+{
+namespace cpgrid
+{
+std::vector<int> zoltanGraphPartitionGrid(const CpGrid& cpgrid,
+                                          const CollectiveCommunication<MPI_Comm>& cc,
+                                          bool globalGridOnAllProcs)
+{
+    int rc;
+    float ver;
+    struct Zoltan_Struct *zz;
+    int changes, numGidEntries, numLidEntries, numImport, numExport;
+    ZOLTAN_ID_PTR importGlobalGids, importLocalGids, exportGlobalGids, exportLocalGids;
+    int *importProcs, *importToPart, *exportProcs, *exportToPart;
+    int argc=0;
+    char** argv;
+    rc = Zoltan_Initialize(argc, argv, &ver);
+    zz = Zoltan_Create(cc);
+    if ( rc != ZOLTAN_OK )
+    {
+        OPM_THROW(std::runtime_error, "Could not initialize Zoltan!");
+    }
+
+    Zoltan_Set_Param(zz, "DEBUG_LEVEL", "0");
+    Zoltan_Set_Param(zz, "LB_METHOD", "GRAPH");
+    Zoltan_Set_Param(zz, "LB_APPROACH", "PARTITION");
+    Zoltan_Set_Param(zz, "NUM_GID_ENTRIES", "1");
+    Zoltan_Set_Param(zz, "NUM_LID_ENTRIES", "1");
+    Zoltan_Set_Param(zz, "RETURN_LISTS", "ALL");
+    Zoltan_Set_Param(zz, "DEBUG_LEVEL", "3");
+    Zoltan_Set_Param(zz, "CHECK_GRAPH", "2");
+    Zoltan_Set_Param(zz, "PHG_EDGE_SIZE_THRESHOLD", ".35");  /* 0-remove all, 1-remove none */
+
+    bool pretendEmptyGrid = globalGridOnAllProcs?(cc.rank()!=0):false;
+
+    Dune::cpgrid::setCpGridZoltanGraphFunctions(zz, cpgrid, pretendEmptyGrid);
+
+    rc = Zoltan_LB_Partition(zz, /* input (all remaining fields are output) */
+                             &changes,        /* 1 if partitioning was changed, 0 otherwise */
+                             &numGidEntries,  /* Number of integers used for a global ID */
+                             &numLidEntries,  /* Number of integers used for a local ID */
+                             &numImport,      /* Number of vertices to be sent to me */
+                             &importGlobalGids,  /* Global IDs of vertices to be sent to me */
+                             &importLocalGids,   /* Local IDs of vertices to be sent to me */
+                             &importProcs,    /* Process rank for source of each incoming vertex */
+                             &importToPart,   /* New partition for each incoming vertex */
+                             &numExport,      /* Number of vertices I must send to other processes*/
+                             &exportGlobalGids,  /* Global IDs of the vertices I must send */
+                             &exportLocalGids,   /* Local IDs of the vertices I must send */
+                             &exportProcs,    /* Process to which I send each of the vertices */
+                             &exportToPart);  /* Partition to which each vertex will belong */
+    int size = cpgrid.numCells();
+    int         rank  = cc.rank();
+    std::vector<int> parts=std::vector<int>(size, rank);
+
+    for ( int i=0; i < numExport; ++i )
+    {
+        parts[exportLocalGids[i]] = exportProcs[i];
+    }
+
+    if ( globalGridOnAllProcs )
+    {
+        cc.broadcast(&parts[0], parts.size(), 0);
+    }
+
+    Zoltan_LB_Free_Part(&exportGlobalGids, &exportLocalGids, &exportProcs, &exportToPart);
+    Zoltan_LB_Free_Part(&importGlobalGids, &importLocalGids, &importProcs, &importToPart);
+    Zoltan_Destroy(&zz);
+    return parts;
+}
+}
+}
+#endif // HAVE_ZOLTAN

--- a/dune/grid/common/ZoltanPartition.cpp
+++ b/dune/grid/common/ZoltanPartition.cpp
@@ -21,7 +21,7 @@
 #include <config.h>
 #endif
 #include <dune/grid/common/ZoltanPartition.hpp>
-#ifdef HAVE_ZOLTAN
+#if defined(HAVE_ZOLTAN) && defined(HAVE_MPI)
 namespace Dune
 {
 namespace cpgrid

--- a/dune/grid/common/ZoltanPartition.cpp
+++ b/dune/grid/common/ZoltanPartition.cpp
@@ -1,6 +1,5 @@
 /*
   Copyright 2015 Dr. Blatt - HPC-Simulation-Software & Services.
-  Copyright 2015 NTNU
   Copyright 2015 Statoil AS
 
   This file is part of The Open Porous Media project  (OPM).

--- a/dune/grid/common/ZoltanPartition.hpp
+++ b/dune/grid/common/ZoltanPartition.hpp
@@ -38,13 +38,12 @@ namespace cpgrid
 /// @param grid The grid to partition
 /// @paramm cc  The MPI communicator to use for the partitioning.
 ///             The will be partitioned among the partiticipating processes.
-/// @param globalGridOnAllProcs If true, we will only extract the information
-///             on the master process for the partitioning.
+/// @param root The process number that holds the global grid.
 /// @return A vector that contains for each local cell of the grid the
 ///         the number of the process that owns it after repartitioning.
-std::vector<int> zoltanGraphPartitionGrid(const CpGrid& grid,
-                                          const CollectiveCommunication<MPI_Comm>& cc,
-                                          bool globalGridOnAllProcs=true);
+std::vector<int> zoltanGraphPartitionGridOnRoot(const CpGrid& grid,
+                                                const CollectiveCommunication<MPI_Comm>& cc,
+                                                int root);
 }
 }
 #endif // HAVE_ZOLTAN

--- a/dune/grid/common/ZoltanPartition.hpp
+++ b/dune/grid/common/ZoltanPartition.hpp
@@ -1,0 +1,38 @@
+/*
+  Copyright 2015 Dr. Blatt - HPC-Simulation-Software & Services.
+  Copyright 2015 NTNU
+  Copyright 2015 Statoil AS
+
+  This file is part of The Open Porous Media project  (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef DUNE_CPGRID_ZOLTANPARTITION_HEADER
+#define DUNE_CPGRID_ZOLTANPARTITION_HEADER
+
+#include <dune/grid/CpGrid.hpp>
+#include <dune/grid/common/ZoltanGraphFunctions.hpp>
+
+#if HAVE_ZOLTAN
+namespace Dune
+{
+namespace cpgrid
+{
+std::vector<int> zoltanGraphPartitionGrid(const CpGrid& grid,
+                                          const CollectiveCommunication<MPI_Comm>& cc,
+                                          bool globalGridOnAllProcs);
+}
+}
+#endif // HAVE_ZOLTAN
+#endif // header guard

--- a/dune/grid/common/ZoltanPartition.hpp
+++ b/dune/grid/common/ZoltanPartition.hpp
@@ -23,7 +23,7 @@
 #include <dune/grid/CpGrid.hpp>
 #include <dune/grid/common/ZoltanGraphFunctions.hpp>
 
-#if HAVE_ZOLTAN
+#if defined(HAVE_ZOLTAN) && defined(HAVE_MPI)
 namespace Dune
 {
 namespace cpgrid

--- a/dune/grid/common/ZoltanPartition.hpp
+++ b/dune/grid/common/ZoltanPartition.hpp
@@ -28,9 +28,23 @@ namespace Dune
 {
 namespace cpgrid
 {
+/// \brief Partition a CpGrid using Zoltan
+///
+/// This function will extract Zoltan's graph information
+/// form the grid and use it to partition it.
+/// In case the global grid is available on all processes, it
+/// will nevertheless only use the information on the root process
+/// to partition it as Zoltan cannot identify this situation.
+/// @param grid The grid to partition
+/// @paramm cc  The MPI communicator to use for the partitioning.
+///             The will be partitioned among the partiticipating processes.
+/// @param globalGridOnAllProcs If true, we will only extract the information
+///             on the master process for the partitioning.
+/// @return A vector that contains for each local cell of the grid the
+///         the number of the process that owns it after repartitioning.
 std::vector<int> zoltanGraphPartitionGrid(const CpGrid& grid,
                                           const CollectiveCommunication<MPI_Comm>& cc,
-                                          bool globalGridOnAllProcs);
+                                          bool globalGridOnAllProcs=true);
 }
 }
 #endif // HAVE_ZOLTAN

--- a/dune/grid/common/ZoltanPartition.hpp
+++ b/dune/grid/common/ZoltanPartition.hpp
@@ -1,6 +1,5 @@
 /*
   Copyright 2015 Dr. Blatt - HPC-Simulation-Software & Services.
-  Copyright 2015 NTNU
   Copyright 2015 Statoil AS
 
   This file is part of The Open Porous Media project  (OPM).

--- a/dune/grid/cpgrid/CpGrid.cpp
+++ b/dune/grid/cpgrid/CpGrid.cpp
@@ -40,6 +40,7 @@
 #endif
 #include "../CpGrid.hpp"
 #include "CpGridData.hpp"
+#include <dune/grid/common/ZoltanPartition.hpp>
 #include <dune/grid/common/GridPartitioning.hpp>
 #include <opm/core/utility/parameters/ParameterGroup.hpp>
 
@@ -98,12 +99,16 @@ bool CpGrid::scatterGrid(int overlapLayers)
 
     std::vector<int> cell_part(current_view_data_->global_cell_.size());
     int my_num=cc.rank();
+#ifdef HAVE_ZOLTAN
+    cell_part = cpgrid::zoltanGraphPartitionGrid(*this, cc, true);
+    int num_parts = cc.size();
+#else
     int  num_parts=-1;
     std::array<int, 3> initial_split;
     initial_split[1]=initial_split[2]=std::pow(cc.size(), 1.0/3.0);
     initial_split[0]=cc.size()/(initial_split[1]*initial_split[2]);
     partition(*this, initial_split, num_parts, cell_part);
-
+#endif
 
     MPI_Comm new_comm = MPI_COMM_NULL;
 

--- a/dune/grid/cpgrid/CpGrid.cpp
+++ b/dune/grid/cpgrid/CpGrid.cpp
@@ -100,7 +100,7 @@ bool CpGrid::scatterGrid(int overlapLayers)
     std::vector<int> cell_part(current_view_data_->global_cell_.size());
     int my_num=cc.rank();
 #ifdef HAVE_ZOLTAN
-    cell_part = cpgrid::zoltanGraphPartitionGrid(*this, cc, true);
+    cell_part = cpgrid::zoltanGraphPartitionGridOnRoot(*this, cc, 0);
     int num_parts = cc.size();
 #else
     int  num_parts=-1;

--- a/tests/cpgrid/distribution_test.cpp
+++ b/tests/cpgrid/distribution_test.cpp
@@ -250,8 +250,8 @@ BOOST_AUTO_TEST_CASE(distribute)
     const Dune::CpGrid::GlobalIdSet& unbalanced_gid_set=grid.globalIdSet();
 
     grid.communicate(data, Dune::All_All_Interface, Dune::ForwardCommunication);
-
     grid.loadBalance(data);
+    
     if ( grid.numCells())
     {
         std::array<int,3> ijk;

--- a/tests/cpgrid/zoltan_test.cpp
+++ b/tests/cpgrid/zoltan_test.cpp
@@ -43,6 +43,7 @@ public:
   int errorcode;
 };
 
+#ifdef HAVE_MPI
 void MPI_err_handler(MPI_Comm *, int *err_code, ...){
   char *err_string=new char[MPI_MAX_ERROR_STRING];
   int err_length;
@@ -52,7 +53,7 @@ void MPI_err_handler(MPI_Comm *, int *err_code, ...){
   delete[] err_string;
   throw MPIError(s, *err_code);
 }
-
+#endif
 
 BOOST_AUTO_TEST_CASE(zoltan)
 {
@@ -61,7 +62,9 @@ BOOST_AUTO_TEST_CASE(zoltan)
     char** m_argv = boost::unit_test::framework::master_test_suite().argv;
     {
         auto& inst = Dune::MPIHelper::instance(m_argc, m_argv);
-#ifdef HAVE_ZOLTAN
+        (void) inst; //omit unused variable warning.
+
+#if defined(HAVE_ZOLTAN) && defined(HAVE_MPI)
         int rc;
         float ver;
         int procs=1;

--- a/tests/cpgrid/zoltan_test.cpp
+++ b/tests/cpgrid/zoltan_test.cpp
@@ -1,0 +1,162 @@
+/*
+  Copyright 2015 Dr. Blatt - HPC-Simulation-Software & Services.
+  Copyright 2015 NTNU
+  Copyright 2015 Statoil AS
+
+  This file is part of The Open Porous Media project  (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include <config.h>
+#define ONE_TO_ALL
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
+#define BOOST_TEST_MODULE ZoltanTests
+#include <boost/test/unit_test.hpp>
+
+#include <dune/grid/CpGrid.hpp>
+#include <dune/grid/common/ZoltanGraphFunctions.hpp>
+
+// Warning suppression for Dune includes.
+#include <opm/core/utility/platform_dependent/disable_warnings.h>
+
+
+class MPIError {
+public:
+  /** @brief Constructor. */
+  MPIError(std::string s, int e) : errorstring(s), errorcode(e){}
+  /** @brief The error string. */
+  std::string errorstring;
+  /** @brief The mpi error code. */
+  int errorcode;
+};
+
+void MPI_err_handler(MPI_Comm *, int *err_code, ...){
+  char *err_string=new char[MPI_MAX_ERROR_STRING];
+  int err_length;
+  MPI_Error_string(*err_code, err_string, &err_length);
+  std::string s(err_string, err_length);
+  std::cerr << "An MPI Error ocurred:"<<std::endl<<s<<std::endl;
+  delete[] err_string;
+  throw MPIError(s, *err_code);
+}
+
+
+BOOST_AUTO_TEST_CASE(zoltan)
+{
+
+    int m_argc = boost::unit_test::framework::master_test_suite().argc;
+    char** m_argv = boost::unit_test::framework::master_test_suite().argv;
+    {
+        auto& inst = Dune::MPIHelper::instance(m_argc, m_argv);
+#ifdef HAVE_ZOLTAN
+        int rc;
+        float ver;
+        int procs=1;
+        struct Zoltan_Struct *zz;
+        int changes, numGidEntries, numLidEntries, numImport, numExport;
+        int myRank, numProcs;
+        ZOLTAN_ID_PTR importGlobalGids, importLocalGids, exportGlobalGids, exportLocalGids;
+        int *importProcs, *importToPart, *exportProcs, *exportToPart;
+        rc = Zoltan_Initialize(m_argc, m_argv, &ver);
+        BOOST_REQUIRE (rc == ZOLTAN_OK);
+
+        //#ifdef ONE_TO_ALL
+        //zz = Zoltan_Create(MPI_COMM_SELF);
+        //#else
+        zz = Zoltan_Create(MPI_COMM_WORLD);
+        //#endif
+
+        /* General parameters */
+        Zoltan_Set_Param(zz, "DEBUG_LEVEL", "0");
+        Zoltan_Set_Param(zz, "LB_METHOD", "GRAPH");
+        Zoltan_Set_Param(zz, "LB_APPROACH", "PARTITION");
+        Zoltan_Set_Param(zz, "NUM_GID_ENTRIES", "1");
+        Zoltan_Set_Param(zz, "NUM_LID_ENTRIES", "1");
+        Zoltan_Set_Param(zz, "RETURN_LISTS", "ALL");
+        Zoltan_Set_Param(zz, "DEBUG_LEVEL", "3");
+#ifdef ONE_TO_ALL
+        //    Zoltan_Set_Param(zz, "NUM_GLOBAL_PARTS", std::to_string((long long)inst.size()).c_str());
+#endif
+        /* Graph parameters */
+
+        Zoltan_Set_Param(zz, "CHECK_GRAPH", "2");
+        Zoltan_Set_Param(zz, "PHG_EDGE_SIZE_THRESHOLD", ".35");  /* 0-remove all, 1-remove none */
+
+        MPI_Errhandler handler;
+        MPI_Errhandler_create(MPI_err_handler, &handler);
+        MPI_Errhandler_set(MPI_COMM_WORLD, handler);
+        MPI_Comm_size(MPI_COMM_WORLD, &procs);
+        MPI_Comm_rank(MPI_COMM_WORLD, &myRank);
+
+        Dune::CpGrid grid;
+        std::array<int, 3> dims={{1, 2, 2}};
+        std::array<int, 3> nulldims={{0, 0, 0}};
+        std::array<double, 3> size={{ 1.0, 1.0, 1.0}};
+#ifdef ONE_TO_ALL
+        if (myRank==0)
+#endif
+            grid.createCartesian(dims, size);
+
+        Dune::cpgrid::setCpGridZoltanGraphFunctions(zz, grid);
+
+        BOOST_REQUIRE(grid.comm()==MPI_COMM_SELF);
+
+        //ZOLTAN_TRACE_ENTER(zz, yo);
+        rc = Zoltan_LB_Partition(zz, /* input (all remaining fields are output) */
+                                 &changes,        /* 1 if partitioning was changed, 0 otherwise */
+                                 &numGidEntries,  /* Number of integers used for a global ID */
+                                 &numLidEntries,  /* Number of integers used for a local ID */
+                                 &numImport,      /* Number of vertices to be sent to me */
+                                 &importGlobalGids,  /* Global IDs of vertices to be sent to me */
+                                 &importLocalGids,   /* Local IDs of vertices to be sent to me */
+                                 &importProcs,    /* Process rank for source of each incoming vertex */
+                                 &importToPart,   /* New partition for each incoming vertex */
+                                 &numExport,      /* Number of vertices I must send to other processes*/
+                                 &exportGlobalGids,  /* Global IDs of the vertices I must send */
+                                 &exportLocalGids,   /* Local IDs of the vertices I must send */
+                                 &exportProcs,    /* Process to which I send each of the vertices */
+                                 &exportToPart);  /* Partition to which each vertex will belong */
+        //ZOLTAN_TRACE_DETAIL(zz, yo, "load balance");
+        BOOST_REQUIRE (rc == ZOLTAN_OK);
+
+        if(myRank > 0)
+        {
+            MPI_Status stat;
+            int i=0;
+            MPI_Recv(&i, 1, MPI_INT, myRank-1, 787, MPI_COMM_WORLD, &stat);
+        }
+        std::cout<<"Begin Rank "<<myRank<<":"<<std::endl;
+        for ( int i=0; i < numExport; i++ )
+        {
+            std::cout<<"e"<<exportLocalGids[i]<<" ("<<exportGlobalGids[i]<<") => part="<<exportToPart[i]<<
+                " proc="<<exportProcs[i]<<", ";
+        }
+        std::cout<<std::endl;
+        for ( int i=0; i < numImport; i++ )
+        {
+            std::cout<<"i"<<importLocalGids[i]<<" ("<<importGlobalGids[i]<<") => part="<<importToPart[i]<<
+                " proc="<<importProcs[i]<<", ";
+        }
+        std::cout<<"End Rank "<<myRank<<":"<<std::endl;
+        std::cout<<std::endl;
+        if(myRank <procs-1)
+        {
+            int i=0;
+            MPI_Send(&i, 1, MPI_INT, myRank+1, 787, MPI_COMM_WORLD);
+        }
+#endif
+    }
+}


### PR DESCRIPTION
This PR now uses ZOLTAN to repartition the grid if it is available. If not, we fall back to the old behaviour. 
It uses the grid information to build the corresponding graph infrastructure on a root process, then applies the parallel graph partitioning of ZOLTAN to it and  broadcasts the information about where each cell will be owned to all processes. According to this the parallel load balanced grid is set up by the old routines.

Note: This PR incorporates OPM/opm-core#787. There it should only be merged after propagating OPM/opm-core#787 to the other modules and rebasing this PR.
