### PR TITLE
Parallel cpr bug fixes

### DIFF
--- a/dune/grid/cpgrid/CpGrid.cpp
+++ b/dune/grid/cpgrid/CpGrid.cpp
@@ -100,8 +100,8 @@ bool CpGrid::scatterGrid(int overlapLayers)
     int my_num=cc.rank();
     int  num_parts=-1;
     std::array<int, 3> initial_split;
-    initial_split[0]=initial_split[1]=std::pow(cc.size(), 1.0/3.0);
-    initial_split[2]=cc.size()/(initial_split[0]*initial_split[1]);
+    initial_split[1]=initial_split[2]=std::pow(cc.size(), 1.0/3.0);
+    initial_split[0]=cc.size()/(initial_split[1]*initial_split[2]);
     partition(*this, initial_split, num_parts, cell_part);
 
 

--- a/dune/grid/cpgrid/CpGridData.cpp
+++ b/dune/grid/cpgrid/CpGridData.cpp
@@ -588,7 +588,7 @@ void CpGridData::distributeGlobalGrid(const CpGrid& grid,
                 if(iter!=ov.end())
                 {
                     global2local.push_back(count);
-                    indexset->add(i, Index(count++, AttributeSet::overlap, true));
+                    indexset->add(i, Index(count++, AttributeSet::copy, true));
                     neighbors.insert(ov.begin(), iter);
                     neighbors.insert(++iter, ov.end());
                 }

--- a/tests/cpgrid/distribution_test.cpp
+++ b/tests/cpgrid/distribution_test.cpp
@@ -252,8 +252,11 @@ BOOST_AUTO_TEST_CASE(distribute)
     grid.communicate(data, Dune::All_All_Interface, Dune::ForwardCommunication);
 
     grid.loadBalance(data);
-    std::array<int,3> ijk;
-    grid.getIJK(0, ijk);
+    if ( grid.numCells())
+    {
+        std::array<int,3> ijk;
+        grid.getIJK(0, ijk);
+    }
 
 #if HAVE_MPI && DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
     // Dune::CpGrid::loadBalance() is non-trivial only if we have MPI


### PR DESCRIPTION
This PR contains several fixes to small bugs found when testing the parallel CPR preconditioner:

- Accessing empty containers
- Bad loadbalancing
- Wrong labelling of halo cells for AMG