### PR TITLE
Use correct filename in public header file list

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -108,6 +108,6 @@ list (APPEND PUBLIC_HEADER_FILES
 	dune/grid/cpgrid/PartitionIteratorRule.hpp
 	dune/grid/cpgrid/PartitionTypeIndicator.hpp
 	dune/grid/cpgrid/PersistentContainer.hpp
-	dune/grid/common/ZoltanGridFunctions.hpp
+	dune/grid/common/ZoltanGraphFunctions.hpp
 	dune/grid/common/ZoltanPartition.hpp
 	)


### PR DESCRIPTION
This fixes `make install`.