### PR TITLE
PolyhedralGrid: disable grid check for all dune versions < 2.4

### DIFF
--- a/tests/polyhedralgrid_test.cc
+++ b/tests/polyhedralgrid_test.cc
@@ -10,8 +10,6 @@
 #define DISABLE_DEPRECATED_METHOD_CHECK 1
 #if DUNE_VERSION_NEWER(DUNE_GRID,2,4)
 #include <dune/grid/test/gridcheck.hh>
-#elif DUNE_VERSION_NEWER(DUNE_GRID,2,3)
-#include <dune/grid/test/gridcheck.cc>
 #endif
 
 // Re-enable warnings.
@@ -108,7 +106,7 @@ int main()
     typedef Grid::LeafGridView GridView;
     Grid grid(deck, porv);
 
-#if DUNE_VERSION_NEWER(DUNE_GRID,2,3)
+#if DUNE_VERSION_NEWER(DUNE_GRID,2,4)
     try {
       gridcheck( grid );
     }


### PR DESCRIPTION
The gridcheck for checking the dune-grid interface implementation has a small bug when used with grid that do not provide sizes for all codimensions. I have fixed this in the current 2.4 version. 
For all prior versions we simply disable the gridcheck.