### PR TITLE
Silence warnings

### DIFF
--- a/dune/grid/common/GridAdapter.hpp
+++ b/dune/grid/common/GridAdapter.hpp
@@ -218,7 +218,7 @@ private:
     }
     /// Build (copy of) global cell from grid
     template<class Grid>
-    void buildGlobalCell(const Grid& grid)
+    void buildGlobalCell(const Grid& /*grid*/)
     {
         g_.global_cell=0;
     }
@@ -230,7 +230,7 @@ private:
     }
     /// Copy the cart dims from grid.
     template <class Grid>
-    void copyCartDims(const Grid& grid)
+    void copyCartDims(const Grid& /*grid*/)
     {}
     /// Build (copy of) topological structure from grid.
     template <class Grid>

--- a/dune/grid/cpgrid/CpGrid.cpp
+++ b/dune/grid/cpgrid/CpGrid.cpp
@@ -35,9 +35,13 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
+
 #if HAVE_MPI
+#include <opm/core/utility/platform_dependent/disable_warnings.h>
 #include "mpi.h"
+#include <opm/core/utility/platform_dependent/reenable_warnings.h>
 #endif
+
 #include "../CpGrid.hpp"
 #include "CpGridData.hpp"
 #include <dune/grid/common/ZoltanPartition.hpp>

--- a/tests/cpgrid/distribution_test.cpp
+++ b/tests/cpgrid/distribution_test.cpp
@@ -191,8 +191,8 @@ BOOST_AUTO_TEST_CASE(distribute)
     int procs=1;
 #if HAVE_MPI
     MPI_Errhandler handler;
-    MPI_Errhandler_create(MPI_err_handler, &handler);
-    MPI_Errhandler_set(MPI_COMM_WORLD, handler);
+    MPI_Comm_create_errhandler(MPI_err_handler, &handler);
+    MPI_Comm_set_errhandler(MPI_COMM_WORLD, handler);
     MPI_Comm_size(MPI_COMM_WORLD, &procs);
 #endif
     Dune::CpGrid grid;

--- a/tests/cpgrid/entityrep_test.cpp
+++ b/tests/cpgrid/entityrep_test.cpp
@@ -41,7 +41,9 @@
 
 
 #define BOOST_TEST_MODULE EntityRepTests
+#include <opm/core/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
+#include <opm/core/utility/platform_dependent/reenable_warnings.h>
 
 #include <dune/grid/cpgrid/EntityRep.hpp>
 


### PR DESCRIPTION
With this, dune-cornerpoint compiles without warnings on my system.

@blattms: when you have time, I'd appreciate if you could verify that we should be using the MPI-2 version of the errhandler functions (see the distribution_test.cpp change).