### PR TITLE
Add possibility to use well information when partitioning.

### DIFF
--- a/dune/grid/CpGrid.hpp
+++ b/dune/grid/CpGrid.hpp
@@ -568,6 +568,12 @@ namespace Dune
 
         /// \brief Distributes this grid over the available nodes in a distributed machine
         /// \param ecl Pointer to the eclipse state information. Default: null
+        ///            If this is not null then complete well information of
+        ///            of the last scheduler step of the eclipse state will be
+        ///            used to make sure that all the possible completion cells
+        ///            of each well are stored on one process. This done by
+        ///            adding an edge with a very high edge weight for all
+        ///            possible pairs of cells in the completion set of a well.
         /// \param The number of layers of cells of the overlap region (default: 1).
         /// \warning May only be called once.
         bool loadBalance(Opm::EclipseStateConstPtr ecl=Opm::EclipseStateConstPtr(),
@@ -579,6 +585,12 @@ namespace Dune
         /// \brief Distributes this grid and data over the available nodes in a distributed machine.
         /// \param data A data handle describing how to distribute attached data.
         /// \param ecl Pointer to the eclipse state information. Default: null
+        ///            If this is not null then complete well information of
+        ///            of the last scheduler step of the eclipse state will be
+        ///            used to make sure that all the possible completion cells
+        ///            of each well are stored on one process. This done by
+        ///            adding an edge with a very high edge weight for all
+        ///            possible pairs of cells in the completion set of a well.
         /// \param overlapLayers The number of layers of overlap cells to be added
         ///        (default: 1)
         /// \tparam DataHandle The type implementing DUNE's DataHandle interface.
@@ -1057,7 +1069,14 @@ namespace Dune
 #endif
 
     private:
-        /// Scatter a global grid to all processors.
+        /// \brief Scatter a global grid to all processors.
+        /// \param ecl Pointer to the eclipse state information. Default: null
+        ///            If this is not null then complete well information of
+        ///            of the last scheduler step of the eclipse state will be
+        ///            used to make sure that all the possible completion cells
+        ///            of each well are stored on one process. This done by
+        ///            adding an edge with a very high edge weight for all
+        ///            possible pairs of cells in the completion set of a well.
         bool scatterGrid(Opm::EclipseStateConstPtr ecl, int overlapLayers);
 
         /** @brief The data stored in the grid.

--- a/dune/grid/CpGrid.hpp
+++ b/dune/grid/CpGrid.hpp
@@ -46,6 +46,8 @@
 // Warning suppression for Dune includes.
 #include <opm/core/utility/platform_dependent/disable_warnings.h>
 
+#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+
 #include <dune/grid/common/capabilities.hh>
 #include <dune/grid/common/grid.hh>
 #include <dune/grid/common/gridenums.hh>
@@ -565,23 +567,28 @@ namespace Dune
         // loadbalance is not part of the grid interface therefore we skip it.
 
         /// \brief Distributes this grid over the available nodes in a distributed machine
+        /// \param ecl Pointer to the eclipse state information. Default: null
         /// \param The number of layers of cells of the overlap region (default: 1).
         /// \warning May only be called once.
-        bool loadBalance(int overlapLayers=1)
+        bool loadBalance(Opm::EclipseStateConstPtr ecl=Opm::EclipseStateConstPtr(),
+                         int overlapLayers=1)
         {
-            return scatterGrid(overlapLayers);
+            return scatterGrid(ecl, overlapLayers);
         }
 
         /// \brief Distributes this grid and data over the available nodes in a distributed machine.
         /// \param data A data handle describing how to distribute attached data.
+        /// \param ecl Pointer to the eclipse state information. Default: null
         /// \param overlapLayers The number of layers of overlap cells to be added
         ///        (default: 1)
         /// \tparam DataHandle The type implementing DUNE's DataHandle interface.
         /// \warning May only be called once.
         template<class DataHandle>
-        bool loadBalance(DataHandle& data, int overlapLayers=1)
+        bool loadBalance(DataHandle& data,
+                         Opm::EclipseStateConstPtr ecl=Opm::EclipseStateConstPtr(),
+                         int overlapLayers=1)
         {
-            bool ret = scatterGrid(overlapLayers);
+            bool ret = scatterGrid(ecl, overlapLayers);
             scatterData(data);
             return ret;
         }
@@ -1051,7 +1058,7 @@ namespace Dune
 
     private:
         /// Scatter a global grid to all processors.
-        bool scatterGrid(int overlapLayers);
+        bool scatterGrid(Opm::EclipseStateConstPtr ecl, int overlapLayers);
 
         /** @brief The data stored in the grid.
          *

--- a/dune/grid/common/ZoltanGraphFunctions.cpp
+++ b/dune/grid/common/ZoltanGraphFunctions.cpp
@@ -256,7 +256,6 @@ void getCpGridWellsEdgeList(void *graphPointer, int sizeGID, int sizeLID,
 
         // First the strong edges of the well completions.
         auto wellEdges = graph.getWellsGraph()[currentCell];
-        well_perf += wellEdges.size();
         for( auto edge : wellEdges)
         {
             nborGID[idx] = edge;

--- a/dune/grid/common/ZoltanGraphFunctions.cpp
+++ b/dune/grid/common/ZoltanGraphFunctions.cpp
@@ -323,9 +323,10 @@ CombinedGridWellGraph::CombinedGridWellGraph(const CpGrid& grid,
     : grid_(grid)
 {
     wellsGraph_.resize(grid.numCells());
+    const auto& cpgdim = grid.logicalCartesianSize();
     // create compressed lookup from cartesian.
     std::vector<Opm::WellConstPtr> wells  = eclipseState->getSchedule()->getWells();
-    std::vector<int> cartesian_to_compressed(grid.numCells(), -1);
+    std::vector<int> cartesian_to_compressed(cpgdim[0]*cpgdim[1]*cpgdim[2], -1);
     int last_time_step = eclipseState->getSchedule()->getTimeMap()->size()-1;
     for( int i=0; i < grid.numCells(); ++i )
     {
@@ -341,7 +342,6 @@ CombinedGridWellGraph::CombinedGridWellGraph(const CpGrid& grid,
             int i = completion->getI();
             int j = completion->getJ();
             int k = completion->getK();
-            const auto cpgdim = grid.logicalCartesianSize();
             int cart_grid_idx = i + cpgdim[0]*(j + cpgdim[1]*k);
             int compressed_idx = cartesian_to_compressed[cart_grid_idx];
             assert(compressed_idx>=0);

--- a/dune/grid/common/ZoltanGraphFunctions.cpp
+++ b/dune/grid/common/ZoltanGraphFunctions.cpp
@@ -21,6 +21,8 @@
 #ifdef HAVE_CONFIG_H
 #include <config.h>
 #endif
+#include <limits>
+#include <opm/parser/eclipse/EclipseState/Schedule/Well.hpp>
 #include <dune/grid/common/ZoltanGraphFunctions.hpp>
 #include <dune/common/parallel/indexset.hh>
 #if defined(HAVE_ZOLTAN) && defined(HAVE_MPI)
@@ -108,9 +110,49 @@ void getCpGridNumEdgesList(void *cpGridPointer, int sizeGID, int sizeLID,
         }
         numEdges[i] = edges;
     }
-    std::cout<<std::endl;
     *err = ZOLTAN_OK;
 }
+
+void getCpGridWellsNumEdgesList(void *graphPointer, int sizeGID, int sizeLID,
+                           int numCells,
+                           ZOLTAN_ID_PTR globalID, ZOLTAN_ID_PTR localID,
+                           int *numEdges, int *err)
+{
+    (void) globalID;
+    const CombinedGridWellGraph& graph =
+        *static_cast<CombinedGridWellGraph*>(graphPointer);
+    const Dune::CpGrid&  grid = graph.getGrid();
+    if ( sizeGID != 1 || sizeLID != 1 || numCells != grid.numCells() )
+    {
+        *err = ZOLTAN_FATAL;
+        return;
+    }
+    for( int i = 0; i < numCells;  i++ )
+    {
+        // Initial set of faces is the ones of the well completions
+        auto edges = graph.getWellsGraph()[i];
+        // For the graph there is an edge only if the face has two neighbors.
+        // Therefore we need to check each face
+        int lid   = localID[i];
+        for ( int local_face = 0; local_face < grid.numCellFaces(static_cast<int>(localID[i])); ++local_face )
+        {
+            const int face  = grid.cellFace(lid, local_face);
+            const int face0 = grid.faceCell(face, 0);
+            const int face1 = grid.faceCell(face, 1);
+
+            if ( face0 != -1 && face1 != -1 )
+            {
+                if ( face0 != i )
+                    edges.insert(face0);
+                else
+                    edges.insert(face1);
+            }
+        }
+        numEdges[i] = edges.size();
+    }
+    *err = ZOLTAN_OK;
+}
+
 void getNullEdgeList(void *cpGridPointer, int sizeGID, int sizeLID,
                        int numCells, ZOLTAN_ID_PTR globalID, ZOLTAN_ID_PTR localID,
                        int *numEdges,
@@ -188,6 +230,130 @@ void getCpGridEdgeList(void *cpGridPointer, int sizeGID, int sizeLID,
 #endif
 }
 
+void getCpGridWellsEdgeList(void *graphPointer, int sizeGID, int sizeLID,
+                       int numCells, ZOLTAN_ID_PTR globalID, ZOLTAN_ID_PTR localID,
+                       int *numEdges,
+                       ZOLTAN_ID_PTR nborGID, int *nborProc,
+                       int wgtDim, float *ewgts, int *err)
+{
+    (void) wgtDim; (void) globalID; (void) numEdges; (void) ewgts;
+    assert(wgtDim==1);
+    const CombinedGridWellGraph& graph =
+        *static_cast<const CombinedGridWellGraph*>(graphPointer);
+    const Dune::CpGrid&  grid = graph.getGrid();
+
+    if ( sizeGID != 1 || sizeLID != 1 || numCells != grid.numCells() )
+    {
+        *err = ZOLTAN_FATAL;
+        return;
+    }
+    int oldidx = 0;
+    int idx = 0;
+
+    for( int cell = 0; cell < numCells;  cell++ )
+    {
+        const int currentCell = localID[cell];
+
+        // First the strong edges of the well completions.
+        auto wellEdges = graph.getWellsGraph()[currentCell];
+        well_perf += wellEdges.size();
+        for( auto edge : wellEdges)
+        {
+            nborGID[idx] = edge;
+            ewgts[idx++] = std::numeric_limits<float>::max();
+        }
+
+        // Now the ones of the grid that are not handled by the well completions
+        for ( int local_face = 0 ; local_face < grid.numCellFaces(static_cast<int>(localID[cell])); ++local_face )
+        {
+            const int face  = grid.cellFace(currentCell, local_face);
+            int otherCell   = grid.faceCell(face, 0);
+            if ( otherCell == currentCell || otherCell == -1 )
+            {
+                otherCell = grid.faceCell(face, 1);
+                if ( otherCell == currentCell || otherCell == -1 )
+                {
+                    // no real face or already handled by well
+                    continue;
+                }
+                else
+                {
+                    if ( wellEdges.find(otherCell) == wellEdges.end() )
+                    {
+                        nborGID[idx] = globalID[otherCell];
+                        ewgts[idx++] = 1;
+                    }
+                    continue;
+                }
+            }
+            if ( wellEdges.find(otherCell) == wellEdges.end() )
+            {
+                nborGID[idx] = globalID[otherCell];
+                ewgts[idx++] = 1;
+            }
+        }
+        assert(idx-oldidx==numEdges[cell]);
+        oldidx = idx;
+    }
+
+    const int myrank = grid.comm().rank();
+
+    for ( int i = 0; i < idx; ++i )
+    {
+        nborProc[i] = myrank;
+    }
+#if defined(DEBUG) && false // The index set will not be initialized here!
+    // The above relies heavily on the grid not being distributed already.
+    // Therefore we check here that all cells are owned by us.
+    GlobalLookupIndexSet<Dune::CpGrid::ParallelIndexSet>
+        globalIdxSet(grid.getCellIndexSet(),
+                     grid.numCells());
+    for ( int cell = 0; cell < numCells;  cell++ )
+    {
+        if ( globalIdxSet.pair(cell)->local().attribute() !=
+             Dune::CpGrid::ParallelIndexSet::LocalIndex::Attribute::owner )
+        {
+            *err = ZOLTAN_FATAL;
+        }
+    }
+#endif
+}
+
+CombinedGridWellGraph::CombinedGridWellGraph(const CpGrid& grid,
+                      const Opm::EclipseStateConstPtr eclipseState)
+    : grid_(grid)
+{
+    wellsGraph_.resize(grid.numCells());
+    // create compressed lookup from cartesian.
+    std::vector<Opm::WellConstPtr> wells  = eclipseState->getSchedule()->getWells();
+    std::vector<int> cartesian_to_compressed(grid.numCells(), -1);
+    int last_time_step = eclipseState->getSchedule()->getTimeMap()->size()-1;
+    for( int i=0; i < grid.numCells(); ++i )
+    {
+        cartesian_to_compressed[grid.globalCell()[i]] = i;
+    }
+    // We assume that we know all the wells.
+    for (auto wellIter= wells.begin(); wellIter != wells.end(); ++wellIter) {
+        Opm::WellConstPtr well = (*wellIter);
+        std::set<int> well_indices;
+        Opm::CompletionSetConstPtr completionSet = well->getCompletions(last_time_step);
+        for (size_t c=0; c<completionSet->size(); c++) {
+            Opm::CompletionConstPtr completion = completionSet->get(c);
+            int i = completion->getI();
+            int j = completion->getJ();
+            int k = completion->getK();
+            const auto cpgdim = grid.logicalCartesianSize();
+            int cart_grid_idx = i + cpgdim[0]*(j + cpgdim[1]*k);
+            int compressed_idx = cartesian_to_compressed[cart_grid_idx];
+            assert(compressed_idx>=0);
+            well_indices.insert(compressed_idx);
+        }
+            
+        addCompletionSetToGraph(well_indices);
+            
+    }
+}
+
 void setCpGridZoltanGraphFunctions(Zoltan_Struct *zz, const Dune::CpGrid& grid,
                                    bool pretendNull)
 {
@@ -207,6 +373,29 @@ void setCpGridZoltanGraphFunctions(Zoltan_Struct *zz, const Dune::CpGrid& grid,
         Zoltan_Set_Edge_List_Multi_Fn(zz, getCpGridEdgeList, gridPointer);
     }
 }
+
+    
+void setCpGridZoltanGraphFunctions(Zoltan_Struct *zz,
+                                   const CombinedGridWellGraph& graph,
+                                   bool pretendNull)
+{
+    Dune::CpGrid *gridPointer = const_cast<Dune::CpGrid*>(&graph.getGrid());
+    if ( pretendNull )
+    {
+        Zoltan_Set_Num_Obj_Fn(zz, getNullNumCells, gridPointer);
+        Zoltan_Set_Obj_List_Fn(zz, getNullVertexList, gridPointer);
+        Zoltan_Set_Num_Edges_Multi_Fn(zz, getNullNumEdgesList, gridPointer);
+        Zoltan_Set_Edge_List_Multi_Fn(zz, getNullEdgeList, gridPointer);
+    }
+    else
+    {
+        CombinedGridWellGraph* graphPointer = const_cast<CombinedGridWellGraph*>(&graph);
+        Zoltan_Set_Num_Obj_Fn(zz, getCpGridNumCells, gridPointer);
+        Zoltan_Set_Obj_List_Fn(zz, getCpGridVertexList, gridPointer);
+        Zoltan_Set_Num_Edges_Multi_Fn(zz, getCpGridWellsNumEdgesList, graphPointer);
+        Zoltan_Set_Edge_List_Multi_Fn(zz, getCpGridWellsEdgeList, graphPointer);
+    }
+}   
 } // end namespace cpgrid
 } // end namespace Dune
 #endif // HAVE_ZOLTAN

--- a/dune/grid/common/ZoltanGraphFunctions.hpp
+++ b/dune/grid/common/ZoltanGraphFunctions.hpp
@@ -123,7 +123,7 @@ class CombinedGridWellGraph
 public:
     typedef std::vector<std::set<int> > GraphType;
 
-    /// \brief Create a grapg representing a grid together with the wells.
+    /// \brief Create a graph representing a grid together with the wells.
     /// \param grid The grid.
     /// \param eclipseState The eclipse state to extract the well information from.
     CombinedGridWellGraph(const Dune::CpGrid& grid,

--- a/dune/grid/common/ZoltanGraphFunctions.hpp
+++ b/dune/grid/common/ZoltanGraphFunctions.hpp
@@ -21,6 +21,7 @@
 #ifndef DUNE_CPGRID_ZOLTAN_GRAPH_FUNCTIONS_HEADER
 #define DUNE_CPGRID_ZOLTAN_GRAPH_FUNCTIONS_HEADER
 
+#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <dune/grid/CpGrid.hpp>
 
 #if defined(HAVE_ZOLTAN) && defined(HAVE_MPI)
@@ -97,12 +98,81 @@ inline int getNullNumCells(void* cpGridPointer, int* err)
     return 0;
 }
 
+/// \brief Get the number of edges the graph of the grid and the wells.
+void getCpGridWellsNumEdgesList(void *cpGridWellsPointer, int sizeGID, int sizeLID,
+                           int numCells,
+                           ZOLTAN_ID_PTR globalID, ZOLTAN_ID_PTR localID,
+                           int *numEdges, int *err);
+
+/// \brief Get the list of edges of the graph of the grid and the wells
+void getCpGridWellsEdgeList(void *cpGridWellsPointer, int sizeGID, int sizeLID,
+                       int numCells, ZOLTAN_ID_PTR globalID, ZOLTAN_ID_PTR localID,
+                       int *num_edges,
+                       ZOLTAN_ID_PTR nborGID, int *nborProc,
+                       int wgt_dim, float *ewgts, int *err);
+
+/// \brief A graph repesenting a grid together with the well completions.
+///
+/// The edges of the graph are formed by the superset of the edges representing
+/// the faces of the grid and the ones that represent the connections within the
+/// wells. If a well has completions
+/// on cell i and cell j, then there is an edge from i to j and j to i in the graph.
+/// Even for shut wells the connections will exist.
+class CombinedGridWellGraph
+{
+public:
+    typedef std::vector<std::set<int> > GraphType;
+
+    /// \brief Create a grapg representing a grid together with the wells.
+    /// \param grid The grid.
+    /// \param eclipseState The eclipse state to extract the well information from.
+    CombinedGridWellGraph(const Dune::CpGrid& grid,
+                          const Opm::EclipseStateConstPtr eclipseState);
+
+    /// \brief Access the grid.
+    const Dune::CpGrid& getGrid() const
+    {
+        return grid_;
+    }
+
+    const GraphType& getWellsGraph() const
+    {
+        return wellsGraph_;
+    }
+    
+private:
+    void addCompletionSetToGraph(std::set<int>& well_indices)
+    {
+        for( auto well_idx = well_indices.begin(); well_idx != well_indices.end();
+             ++well_idx)
+        {
+            auto well_idx2 = well_idx;
+            for( ++well_idx2; well_idx2 != well_indices.end();
+                 ++well_idx2)
+            {
+                wellsGraph_[*well_idx].insert(*well_idx2);
+                wellsGraph_[*well_idx2].insert(*well_idx);
+            }
+        }
+
+    }
+    
+        
+    const Dune::CpGrid& grid_;
+    GraphType wellsGraph_;
+};
+
+
 /// \brief Sets up the call-back functions for ZOLTAN's graph partitioning.
 /// \param zz The struct with the information for ZOLTAN.
 /// \param grid The grid to partition.
 /// \param pretendNull If true, we will pretend that the grid has zero cells.
 void setCpGridZoltanGraphFunctions(Zoltan_Struct *zz, const Dune::CpGrid& grid,
                                    bool pretendNull=false);
+
+void setCpGridZoltanGraphFunctions(Zoltan_Struct *zz,
+                                   const CombinedGridWellGraph& graph,
+                                   bool pretendNull);
 } // end namespace cpgrid
 } // end namespace Dune
 

--- a/dune/grid/common/ZoltanPartition.cpp
+++ b/dune/grid/common/ZoltanPartition.cpp
@@ -113,7 +113,7 @@ std::vector<int> zoltanGraphPartitionGridOnRoot(const CpGrid& cpgrid,
             }
             if ( cells_on_other.size() )
             {
-                OPM_THROW(std::domain_error, "Well is distributed between proceses, which should not be the case!");
+                OPM_THROW(std::domain_error, "Well is distributed between processes, which should not be the case!");
             }
             ++index;
         }

--- a/dune/grid/common/ZoltanPartition.cpp
+++ b/dune/grid/common/ZoltanPartition.cpp
@@ -27,8 +27,9 @@ namespace Dune
 namespace cpgrid
 {
 std::vector<int> zoltanGraphPartitionGridOnRoot(const CpGrid& cpgrid,
-                                          const CollectiveCommunication<MPI_Comm>& cc,
-                                          int root)
+                                                const Opm::EclipseStateConstPtr eclipseState,
+                                                const CollectiveCommunication<MPI_Comm>& cc,
+                                                int root)
 {
     int rc;
     float ver;
@@ -53,11 +54,24 @@ std::vector<int> zoltanGraphPartitionGridOnRoot(const CpGrid& cpgrid,
     Zoltan_Set_Param(zz, "RETURN_LISTS", "ALL");
     Zoltan_Set_Param(zz, "DEBUG_LEVEL", "3");
     Zoltan_Set_Param(zz, "CHECK_GRAPH", "2");
+    Zoltan_Set_Param(zz,"EDGE_WEIGHT_DIM","0");
+    Zoltan_Set_Param(zz, "OBJ_WEIGHT_DIM", "0");
     Zoltan_Set_Param(zz, "PHG_EDGE_SIZE_THRESHOLD", ".35");  /* 0-remove all, 1-remove none */
 
     bool pretendEmptyGrid = cc.rank()!=root;
+    std::shared_ptr<CombinedGridWellGraph> grid_and_wells;
 
-    Dune::cpgrid::setCpGridZoltanGraphFunctions(zz, cpgrid, pretendEmptyGrid);
+    if( eclipseState )
+    {
+        Zoltan_Set_Param(zz,"EDGE_WEIGHT_DIM","1");
+        grid_and_wells.reset(new CombinedGridWellGraph(cpgrid, eclipseState));
+        Dune::cpgrid::setCpGridZoltanGraphFunctions(zz, *grid_and_wells,
+                                                    pretendEmptyGrid);
+    }
+    else
+    {
+        Dune::cpgrid::setCpGridZoltanGraphFunctions(zz, cpgrid, pretendEmptyGrid);
+    }
 
     rc = Zoltan_LB_Partition(zz, /* input (all remaining fields are output) */
                              &changes,        /* 1 if partitioning was changed, 0 otherwise */
@@ -81,6 +95,30 @@ std::vector<int> zoltanGraphPartitionGridOnRoot(const CpGrid& cpgrid,
     {
         parts[exportLocalGids[i]] = exportProcs[i];
     }
+    //#ifndef NDEBUG
+    if( eclipseState )
+    {
+        int index = 0;
+        for( auto well : grid_and_wells->getWellsGraph() )
+        {
+            int part=parts[index];
+            std::set<std::pair<int,int> > cells_on_other;
+
+            for( auto vertex : well )
+            {
+                if( part != parts[vertex] )
+                {
+                    cells_on_other.insert(std::make_pair(vertex, parts[vertex]));
+                }
+            }
+            if ( cells_on_other.size() )
+            {
+                OPM_THROW(std::domain_error, "Well is distributed between proceses, which should not be the case!");
+            }
+            ++index;
+        }
+    }
+//#endif
     cc.broadcast(&parts[0], parts.size(), root);
     Zoltan_LB_Free_Part(&exportGlobalGids, &exportLocalGids, &exportProcs, &exportToPart);
     Zoltan_LB_Free_Part(&importGlobalGids, &importLocalGids, &importProcs, &importToPart);

--- a/dune/grid/common/ZoltanPartition.hpp
+++ b/dune/grid/common/ZoltanPartition.hpp
@@ -31,17 +31,20 @@ namespace cpgrid
 /// \brief Partition a CpGrid using Zoltan
 ///
 /// This function will extract Zoltan's graph information
-/// form the grid and use it to partition it.
+/// form the grid, and the wells and use it to partition the grid.
 /// In case the global grid is available on all processes, it
 /// will nevertheless only use the information on the root process
 /// to partition it as Zoltan cannot identify this situation.
 /// @param grid The grid to partition
+/// @param eclipseState The eclipse state  to extract the well
+///                     information from. If null wells will be neglected.
 /// @paramm cc  The MPI communicator to use for the partitioning.
 ///             The will be partitioned among the partiticipating processes.
 /// @param root The process number that holds the global grid.
 /// @return A vector that contains for each local cell of the grid the
 ///         the number of the process that owns it after repartitioning.
 std::vector<int> zoltanGraphPartitionGridOnRoot(const CpGrid& grid,
+                                                const Opm::EclipseStateConstPtr eclipseState,
                                                 const CollectiveCommunication<MPI_Comm>& cc,
                                                 int root);
 }

--- a/dune/grid/common/ZoltanPartition.hpp
+++ b/dune/grid/common/ZoltanPartition.hpp
@@ -31,7 +31,7 @@ namespace cpgrid
 /// \brief Partition a CpGrid using Zoltan
 ///
 /// This function will extract Zoltan's graph information
-/// form the grid, and the wells and use it to partition the grid.
+/// from the grid, and the wells and use it to partition the grid.
 /// In case the global grid is available on all processes, it
 /// will nevertheless only use the information on the root process
 /// to partition it as Zoltan cannot identify this situation.

--- a/dune/grid/cpgrid/CpGrid.cpp
+++ b/dune/grid/cpgrid/CpGrid.cpp
@@ -36,6 +36,9 @@
 #include "config.h"
 #endif
 
+
+#include <opm/core/utility/parameters/ParameterGroup.hpp>
+
 #if HAVE_MPI
 #include <opm/core/utility/platform_dependent/disable_warnings.h>
 #include "mpi.h"
@@ -46,7 +49,6 @@
 #include "CpGridData.hpp"
 #include <dune/grid/common/ZoltanPartition.hpp>
 #include <dune/grid/common/GridPartitioning.hpp>
-#include <opm/core/utility/parameters/ParameterGroup.hpp>
 
 #include <fstream>
 #include <iostream>
@@ -89,7 +91,7 @@ namespace Dune
     }
 
 
-bool CpGrid::scatterGrid(int overlapLayers)
+bool CpGrid::scatterGrid(Opm::EclipseStateConstPtr ecl, int overlapLayers)
 {
 #if HAVE_MPI && DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
     if(distributed_data_)
@@ -104,7 +106,7 @@ bool CpGrid::scatterGrid(int overlapLayers)
     std::vector<int> cell_part(current_view_data_->global_cell_.size());
     int my_num=cc.rank();
 #ifdef HAVE_ZOLTAN
-    cell_part = cpgrid::zoltanGraphPartitionGridOnRoot(*this, cc, 0);
+    cell_part = cpgrid::zoltanGraphPartitionGridOnRoot(*this, ecl, cc, 0);
     int num_parts = cc.size();
 #else
     int  num_parts=-1;


### PR DESCRIPTION
With this commit one can pass eclipse information to the ```CpGrid::loadbalance``` routine.
If this is done then a graph resembling the well information is used in addition. This graph
has connections for all cells that are perforated by a well (i.e. the cell
is part of the competion set) with all cells that are perforated by the same well.
Then this connectivity is added to the one resembling the grid (cell are vertices,
edges are the faces). The connections of the wells get a very high weight, and the
ones of the grid a low one. This combined graph is then provided to ZOLTAN for
loadbalancing.