### PR TITLE
Fixed several warnings in headers

### DIFF
--- a/dune/grid/CpGrid.hpp
+++ b/dune/grid/CpGrid.hpp
@@ -693,20 +693,20 @@ namespace Dune
             bool b = r[0].orientation();
             bool use_first = a ? b : !b;
             // The number of valid cells.
-            int size = r.size();
+            int r_size = r.size();
             // In the case of only one valid cell, this is the index of it.
             int index = 0;
             if(r[0].index()==std::numeric_limits<int>::max()){
-                assert(size==2);
-                --size;
+                assert(r_size==2);
+                --r_size;
                 index=1;
             }
             if(r.size()>1 && r[1].index()==std::numeric_limits<int>::max())
             {
-                assert(size==2);
-                --size;
+                assert(r_size==2);
+                --r_size;
             }
-            if (size == 2) {
+            if (r_size == 2) {
                 return use_first ? r[0].index() : r[1].index();
             } else {
                 return use_first ? r[index].index() : -1;

--- a/dune/grid/cpgrid/Entity.hpp
+++ b/dune/grid/cpgrid/Entity.hpp
@@ -111,8 +111,8 @@ namespace Dune
             }
 
             /// Constructor taking a grid, entity index and orientation.
-            Entity(const CpGridData& grid, int index, bool orientation)
-                : EntityRep<codim>(index, orientation), pgrid_(&grid)
+            Entity(const CpGridData& grid, int index_arg, bool orientation_arg)
+                : EntityRep<codim>(index_arg, orientation_arg), pgrid_(&grid)
             {
             }
 
@@ -297,8 +297,8 @@ namespace Dune
             }
 
             /// Constructor taking a grid, entity index and orientation.
-            EntityPointer(const CpGridData& grid, int index, bool orientation)
-                : Entity(grid, index, orientation)
+            EntityPointer(const CpGridData& grid, int index_arg, bool orientation_arg)
+                : Entity(grid, index_arg, orientation_arg)
             {
             }
 
@@ -448,9 +448,9 @@ bool Entity<codim>::hasBoundaryIntersections() const
 {
     // Copied implementation from EntityDefaultImplementation,
     // except for not checking LevelIntersectionIterators.
-    typedef LeafIntersectionIterator IntersectionIterator;
-    IntersectionIterator end = ileafend();
-    for (IntersectionIterator it = ileafbegin(); it != end; ++it) {
+    typedef LeafIntersectionIterator Iter;
+    Iter end = ileafend();
+    for (Iter it = ileafbegin(); it != end; ++it) {
         if (it->boundary()) return true;
     }
     return false;

--- a/dune/grid/cpgrid/EntityRep.hpp
+++ b/dune/grid/cpgrid/EntityRep.hpp
@@ -5,7 +5,7 @@
 // Created: Tue Jun  9 11:11:24 2009
 //
 // Author(s): Atgeirr F Rasmussen <atgeirr@sintef.no>
-//            Bård Skaflestad     <bard.skaflestad@sintef.no>
+//            Bï¿½rd Skaflestad     <bard.skaflestad@sintef.no>
 //
 // $Date$
 //
@@ -106,20 +106,20 @@ namespace Dune
             {
             }
             /// @brief Constructor taking an entity index and an orientation.
-            /// @param index Entity index
-            /// @param orientation True if the entity's orientations is positive.
-            EntityRep(int index, bool orientation)
-                : entityrep_(orientation ? index : ~index)
+            /// @param index_arg Entity index
+            /// @param orientation_arg True if the entity's orientations is positive.
+            EntityRep(int index_arg, bool orientation_arg)
+                : entityrep_(orientation_arg ? index_arg : ~index_arg)
             {
-                assert(index >= 0);
+                assert(index_arg >= 0);
             }
             /// @brief Set entity value.
             /// @param index Entity index
             /// @param orientation True if the entity's orientations is positive.
-            void setValue(int index, bool orientation)
+            void setValue(int index_arg, bool orientation_arg)
             {
-                assert(index >= 0);
-                entityrep_ = orientation ? index : ~index;
+                assert(index_arg >= 0);
+                entityrep_ = orientation_arg ? index_arg : ~index_arg;
             }
             /// @brief The (positive) index of an entity. Not a Dune interface method.
             /// @return the (positive) index of an entity.

--- a/dune/grid/cpgrid/Geometry.hpp
+++ b/dune/grid/cpgrid/Geometry.hpp
@@ -5,7 +5,7 @@
 // Created: Fri May 29 23:29:24 2009
 //
 // Author(s): Atgeirr F Rasmussen <atgeirr@sintef.no>
-//            Bård Skaflestad     <bard.skaflestad@sintef.no>
+//            Bï¿½rd Skaflestad     <bard.skaflestad@sintef.no>
 //
 // $Date$
 //
@@ -139,13 +139,13 @@ namespace Dune
             /// Note that this does not give a proper space-filling
             /// embedding of the cell complex in the general (faulted)
             /// case. We should therefore revisit this at some point.
-            GlobalCoordinate global(const LocalCoordinate& local) const
+            GlobalCoordinate global(const LocalCoordinate& local_coord) const
             {
                 static_assert(mydimension == 3, "");
                 static_assert(coorddimension == 3, "");
                 // uvw = { (1-u, 1-v, 1-w), (u, v, w) }
-                LocalCoordinate uvw[2] = { LocalCoordinate(1.0), local };
-                uvw[0] -= local;
+                LocalCoordinate uvw[2] = { LocalCoordinate(1.0), local_coord };
+                uvw[0] -= local_coord;
                 // Access pattern for uvw matching ordering of corners.
                 const int pat[8][3] = { { 0, 0, 0 },
                                         { 1, 0, 0 },
@@ -202,9 +202,9 @@ namespace Dune
             /// J_{ij} = (dg_i/du_j)
             /// where g is the mapping from the reference domain,
             /// and {u_j} are the reference coordinates.
-            double integrationElement(const LocalCoordinate& local) const
+            double integrationElement(const LocalCoordinate& local_coord) const
             {
-                FieldMatrix<ctype, coorddimension, mydimension> Jt = jacobianTransposed(local);
+                FieldMatrix<ctype, coorddimension, mydimension> Jt = jacobianTransposed(local_coord);
                 using namespace GenericGeometry;
                 return MatrixHelper<DuneCoordTraits<double> >::template sqrtDetAAT<3, 3>(Jt);
             }
@@ -249,13 +249,13 @@ namespace Dune
             /// where g is the mapping from the reference domain,
             /// and {u_i} are the reference coordinates.
             const FieldMatrix<ctype, mydimension, coorddimension>
-            jacobianTransposed(const LocalCoordinate& local) const
+            jacobianTransposed(const LocalCoordinate& local_coord) const
             {
                 static_assert(mydimension == 3, "");
                 static_assert(coorddimension == 3, "");
                 // uvw = { (1-u, 1-v, 1-w), (u, v, w) }
-                LocalCoordinate uvw[2] = { LocalCoordinate(1.0), local };
-                uvw[0] -= local;
+                LocalCoordinate uvw[2] = { LocalCoordinate(1.0), local_coord };
+                uvw[0] -= local_coord;
                 // Access pattern for uvw matching ordering of corners.
                 const int pat[8][3] = { { 0, 0, 0 },
                                         { 1, 0, 0 },
@@ -284,9 +284,9 @@ namespace Dune
 
             /// @brief Inverse of Jacobian transposed. \see jacobianTransposed().
             const FieldMatrix<ctype, coorddimension, mydimension>
-            jacobianInverseTransposed(const LocalCoordinate& local) const
+            jacobianInverseTransposed(const LocalCoordinate& local_coord) const
             {
-                FieldMatrix<ctype, coorddimension, mydimension> Jti = jacobianTransposed(local);
+                FieldMatrix<ctype, coorddimension, mydimension> Jti = jacobianTransposed(local_coord);
                 Jti.invert();
                 return Jti;
             }


### PR DESCRIPTION
This fixes several warnings (mostly due to -Wshadow) in headers included in e.g., opm-autodiff. Should have no other side effects.