### PR TITLE
Postprocess loadbalanced partioning for wells

### DIFF
--- a/dune/grid/common/ZoltanGraphFunctions.cpp
+++ b/dune/grid/common/ZoltanGraphFunctions.cpp
@@ -319,9 +319,15 @@ void getCpGridWellsEdgeList(void *graphPointer, int sizeGID, int sizeLID,
 }
 
 CombinedGridWellGraph::CombinedGridWellGraph(const CpGrid& grid,
-                      const Opm::EclipseStateConstPtr eclipseState)
+                                             const Opm::EclipseStateConstPtr eclipseState,
+                                             bool pretendEmptyGrid)
     : grid_(grid)
 {
+    if ( pretendEmptyGrid )
+    {
+        // wellsGraph not needed
+        return;
+    }
     wellsGraph_.resize(grid.numCells());
     const auto& cpgdim = grid.logicalCartesianSize();
     // create compressed lookup from cartesian.
@@ -347,9 +353,7 @@ CombinedGridWellGraph::CombinedGridWellGraph(const CpGrid& grid,
             assert(compressed_idx>=0);
             well_indices.insert(compressed_idx);
         }
-            
         addCompletionSetToGraph(well_indices);
-            
     }
 }
 
@@ -373,7 +377,6 @@ void setCpGridZoltanGraphFunctions(Zoltan_Struct *zz, const Dune::CpGrid& grid,
     }
 }
 
-    
 void setCpGridZoltanGraphFunctions(Zoltan_Struct *zz,
                                    const CombinedGridWellGraph& graph,
                                    bool pretendNull)
@@ -394,7 +397,7 @@ void setCpGridZoltanGraphFunctions(Zoltan_Struct *zz,
         Zoltan_Set_Num_Edges_Multi_Fn(zz, getCpGridWellsNumEdgesList, graphPointer);
         Zoltan_Set_Edge_List_Multi_Fn(zz, getCpGridWellsEdgeList, graphPointer);
     }
-}   
+}
 } // end namespace cpgrid
 } // end namespace Dune
 #endif // HAVE_ZOLTAN

--- a/dune/grid/common/ZoltanGraphFunctions.cpp
+++ b/dune/grid/common/ZoltanGraphFunctions.cpp
@@ -350,13 +350,10 @@ CombinedGridWellGraph::CombinedGridWellGraph(const CpGrid& grid,
             int k = completion->getK();
             int cart_grid_idx = i + cpgdim[0]*(j + cpgdim[1]*k);
             int compressed_idx = cartesian_to_compressed[cart_grid_idx];
-            if ( compressed_idx < 1 )
-            {
-                OPM_THROW(std::runtime_error, "Cell with i,j,k indices " << i << ' ' << j << ' '
-                          << k << " not found in grid (well = " << well->name() << ')');
+            if ( compressed_idx >= 0 ) // Ignore completions in inactive cells.
+            {            
+                well_indices.insert(compressed_idx);
             }
-            
-            well_indices.insert(compressed_idx);
         }
         addCompletionSetToGraph(well_indices);
     }
@@ -398,7 +395,10 @@ void CombinedGridWellGraph::postProcessPartitioningForWells(std::vector<int>& pa
             int k = completion->getK();
             int cart_grid_idx = i + cpgdim[0]*(j + cpgdim[1]*k);
             int compressed_idx = cartesian_to_compressed[cart_grid_idx];
-            assert( compressed_idx >= 0 );
+            if ( compressed_idx >= 0 ) // ignore completions in inactive cells
+            {
+                continue;
+            }
             ++no_completions_on_proc[parts[compressed_idx]];
         }
         if ( no_completions_on_proc.size() > 1 )
@@ -420,6 +420,10 @@ void CombinedGridWellGraph::postProcessPartitioningForWells(std::vector<int>& pa
                  int k = completion->getK();
                  int cart_grid_idx = i + cpgdim[0]*(j + cpgdim[1]*k);
                  int compressed_idx = cartesian_to_compressed[cart_grid_idx];
+                 if ( compressed_idx >= 0 ) // ignore completions in inactive cells
+                 {
+                     continue;
+                 }
                  parts[compressed_idx] = new_owner;
              }
         }

--- a/dune/grid/common/ZoltanGraphFunctions.cpp
+++ b/dune/grid/common/ZoltanGraphFunctions.cpp
@@ -395,7 +395,7 @@ void CombinedGridWellGraph::postProcessPartitioningForWells(std::vector<int>& pa
             int k = completion->getK();
             int cart_grid_idx = i + cpgdim[0]*(j + cpgdim[1]*k);
             int compressed_idx = cartesian_to_compressed[cart_grid_idx];
-            if ( compressed_idx >= 0 ) // ignore completions in inactive cells
+            if ( compressed_idx < 0 ) // ignore completions in inactive cells
             {
                 continue;
             }

--- a/dune/grid/common/ZoltanGraphFunctions.cpp
+++ b/dune/grid/common/ZoltanGraphFunctions.cpp
@@ -350,7 +350,12 @@ CombinedGridWellGraph::CombinedGridWellGraph(const CpGrid& grid,
             int k = completion->getK();
             int cart_grid_idx = i + cpgdim[0]*(j + cpgdim[1]*k);
             int compressed_idx = cartesian_to_compressed[cart_grid_idx];
-            assert(compressed_idx>=0);
+            if ( compressed_idx < 1 )
+            {
+                OPM_THROW(std::runtime_error, "Cell with i,j,k indices " << i << ' ' << j << ' '
+                          << k << " not found in grid (well = " << well->name() << ')');
+            }
+            
             well_indices.insert(compressed_idx);
         }
         addCompletionSetToGraph(well_indices);

--- a/dune/grid/common/ZoltanGraphFunctions.cpp
+++ b/dune/grid/common/ZoltanGraphFunctions.cpp
@@ -420,7 +420,7 @@ void CombinedGridWellGraph::postProcessPartitioningForWells(std::vector<int>& pa
                  int k = completion->getK();
                  int cart_grid_idx = i + cpgdim[0]*(j + cpgdim[1]*k);
                  int compressed_idx = cartesian_to_compressed[cart_grid_idx];
-                 if ( compressed_idx >= 0 ) // ignore completions in inactive cells
+                 if ( compressed_idx < 0 ) // ignore completions in inactive cells
                  {
                      continue;
                  }

--- a/dune/grid/common/ZoltanGraphFunctions.cpp
+++ b/dune/grid/common/ZoltanGraphFunctions.cpp
@@ -385,14 +385,15 @@ void CombinedGridWellGraph::postProcessPartitioningForWells(std::vector<int>& pa
             continue;
         }
         std::map<int,std::size_t> no_completions_on_proc;
-        for (size_t c=0; c<completionSet->size(); c++) {
+        for ( size_t c = 0; c < completionSet->size(); c++  )
+        {
             Opm::CompletionConstPtr completion = completionSet->get(c);
             int i = completion->getI();
             int j = completion->getJ();
             int k = completion->getK();
             int cart_grid_idx = i + cpgdim[0]*(j + cpgdim[1]*k);
             int compressed_idx = cartesian_to_compressed[cart_grid_idx];
-            assert(compressed_idx>=0);
+            assert( compressed_idx >= 0 );
             ++no_completions_on_proc[parts[compressed_idx]];
         }
         if ( no_completions_on_proc.size() > 1 )
@@ -405,8 +406,9 @@ void CombinedGridWellGraph::postProcessPartitioningForWells(std::vector<int>& pa
                                                  return ( p1.second > p2.second );
                                              })->first;
             std::cout << "Manually moving well " << well->name() << " to partition "
-                      << new_owner<<std::endl;
-             for (size_t c=0; c<completionSet->size(); c++) {
+                      << new_owner << std::endl;
+             for ( size_t c = 0; c < completionSet->size(); c++ )
+             {
                  Opm::CompletionConstPtr completion = completionSet->get(c);
                  int i = completion->getI();
                  int j = completion->getJ();

--- a/dune/grid/common/ZoltanGraphFunctions.hpp
+++ b/dune/grid/common/ZoltanGraphFunctions.hpp
@@ -126,8 +126,10 @@ public:
     /// \brief Create a graph representing a grid together with the wells.
     /// \param grid The grid.
     /// \param eclipseState The eclipse state to extract the well information from.
+    /// \param pretendEmptyGrid True if we should pretend the grid and wells are empty.
     CombinedGridWellGraph(const Dune::CpGrid& grid,
-                          const Opm::EclipseStateConstPtr eclipseState);
+                          Opm::EclipseStateConstPtr eclipseState,
+                          bool pretendEmptyGrid);
 
     /// \brief Access the grid.
     const Dune::CpGrid& getGrid() const

--- a/dune/grid/common/ZoltanGraphFunctions.hpp
+++ b/dune/grid/common/ZoltanGraphFunctions.hpp
@@ -141,6 +141,9 @@ public:
     {
         return wellsGraph_;
     }
+    /// \brief Post process partitioning to ensure a well is completely on one process.
+    /// \param[inout] parts The assigned partition numbers for each vertex.
+    void postProcessPartitioningForWells(std::vector<int>& parts);
     
 private:
     void addCompletionSetToGraph(std::set<int>& well_indices)
@@ -161,6 +164,7 @@ private:
     
         
     const Dune::CpGrid& grid_;
+    Opm::EclipseStateConstPtr eclipseState_;
     GraphType wellsGraph_;
 };
 

--- a/dune/grid/common/ZoltanPartition.cpp
+++ b/dune/grid/common/ZoltanPartition.cpp
@@ -102,11 +102,6 @@ std::vector<int> zoltanGraphPartitionGridOnRoot(const CpGrid& cpgrid,
         int index = 0;
         for( auto well : grid_and_wells->getWellsGraph() )
         {
-            if( ! well.size() )
-            {
-                ++index;
-                continue;
-            }
             int part=parts[index];
             std::set<std::pair<int,int> > cells_on_other;
             for( auto vertex : well )

--- a/dune/grid/common/ZoltanPartition.cpp
+++ b/dune/grid/common/ZoltanPartition.cpp
@@ -95,9 +95,9 @@ std::vector<int> zoltanGraphPartitionGridOnRoot(const CpGrid& cpgrid,
     {
         parts[exportLocalGids[i]] = exportProcs[i];
     }
-    //#ifndef NDEBUG
     if( eclipseState && ! pretendEmptyGrid )
     {
+#ifndef NDEBUG
         int index = 0;
         for( auto well : grid_and_wells->getWellsGraph() )
         {
@@ -117,8 +117,8 @@ std::vector<int> zoltanGraphPartitionGridOnRoot(const CpGrid& cpgrid,
             }
             ++index;
         }
+#endif
     }
-//#endif
     cc.broadcast(&parts[0], parts.size(), root);
     Zoltan_LB_Free_Part(&exportGlobalGids, &exportLocalGids, &exportProcs, &exportToPart);
     Zoltan_LB_Free_Part(&importGlobalGids, &importLocalGids, &importProcs, &importToPart);

--- a/dune/grid/common/ZoltanPartition.cpp
+++ b/dune/grid/common/ZoltanPartition.cpp
@@ -64,7 +64,7 @@ std::vector<int> zoltanGraphPartitionGridOnRoot(const CpGrid& cpgrid,
     if( eclipseState )
     {
         Zoltan_Set_Param(zz,"EDGE_WEIGHT_DIM","1");
-        grid_and_wells.reset(new CombinedGridWellGraph(cpgrid, eclipseState));
+        grid_and_wells.reset(new CombinedGridWellGraph(cpgrid, eclipseState, pretendEmptyGrid));
         Dune::cpgrid::setCpGridZoltanGraphFunctions(zz, *grid_and_wells,
                                                     pretendEmptyGrid);
     }
@@ -96,7 +96,7 @@ std::vector<int> zoltanGraphPartitionGridOnRoot(const CpGrid& cpgrid,
         parts[exportLocalGids[i]] = exportProcs[i];
     }
     //#ifndef NDEBUG
-    if( eclipseState )
+    if( eclipseState && ! pretendEmptyGrid )
     {
         int index = 0;
         for( auto well : grid_and_wells->getWellsGraph() )

--- a/dune/grid/common/ZoltanPartition.cpp
+++ b/dune/grid/common/ZoltanPartition.cpp
@@ -97,13 +97,18 @@ std::vector<int> zoltanGraphPartitionGridOnRoot(const CpGrid& cpgrid,
     }
     if( eclipseState && ! pretendEmptyGrid )
     {
+        grid_and_wells->postProcessPartitioningForWells(parts);
 #ifndef NDEBUG
         int index = 0;
         for( auto well : grid_and_wells->getWellsGraph() )
         {
+            if( ! well.size() )
+            {
+                ++index;
+                continue;
+            }
             int part=parts[index];
             std::set<std::pair<int,int> > cells_on_other;
-
             for( auto vertex : well )
             {
                 if( part != parts[vertex] )

--- a/dune/grid/cpgrid/CpGrid.cpp
+++ b/dune/grid/cpgrid/CpGrid.cpp
@@ -139,6 +139,8 @@ bool CpGrid::scatterGrid(Opm::EclipseStateConstPtr ecl, int overlapLayers)
         distributed_data_.reset(new cpgrid::CpGridData(new_comm));
         distributed_data_->distributeGlobalGrid(*this,*this->current_view_data_, cell_part,
                                                 overlapLayers);
+        std::cout<<"After loadbalancing process "<<my_num<<" has "<<
+            distributed_data_->cell_to_face_.size()<<" cells."<<std::endl;
     }
     current_view_data_ = distributed_data_.get();
     return true;

--- a/dune/grid/cpgrid/CpGrid.cpp
+++ b/dune/grid/cpgrid/CpGrid.cpp
@@ -139,8 +139,8 @@ bool CpGrid::scatterGrid(Opm::EclipseStateConstPtr ecl, int overlapLayers)
         distributed_data_.reset(new cpgrid::CpGridData(new_comm));
         distributed_data_->distributeGlobalGrid(*this,*this->current_view_data_, cell_part,
                                                 overlapLayers);
-        std::cout<<"After loadbalancing process "<<my_num<<" has "<<
-            distributed_data_->cell_to_face_.size()<<" cells."<<std::endl;
+        std::cout << "After loadbalancing process " << my_num << " has " <<
+            distributed_data_->cell_to_face_.size() << " cells." << std::endl;
     }
     current_view_data_ = distributed_data_.get();
     return true;


### PR DESCRIPTION
After loadbalancing we make another iteration over the wells to check that they are not cut by the process borders. If that is the case we assign the perforated cells manually to the process with the most completions 
of this cell.

