### PR TITLE
Silence warnings in p2pcommunicator_test.cc.

### DIFF
--- a/tests/p2pcommunicator_test.cc
+++ b/tests/p2pcommunicator_test.cc
@@ -48,11 +48,11 @@ void testBuffer()
     buffer.read( lCheck );
     assert( lVal == lCheck );
     std::vector< double > checkValues( 5 );
-    for( int i=0; i<5; ++i )
-      buffer.read( checkValues[ i ] );
+    for( int j=0; j<5; ++j )
+      buffer.read( checkValues[ j ] );
 #ifndef NDEBUG
-    for( int i=0; i<5; ++i )
-      assert( std::abs(values[ i ] - checkValues[ i ] ) < 1e-12 );
+    for( int j=0; j<5; ++j )
+      assert( std::abs(values[ j ] - checkValues[ j ] ) < 1e-12 );
 #endif
   }
 }
@@ -152,7 +152,6 @@ void testCommunicator( const bool output )
   for( int i=0; i<5; ++i )
   {
     // use handle to perform the same operations as above
-    DataHandle handle( comm, output );
     comm.exchangeCached( handle );
   }
 }

--- a/tests/p2pcommunicator_test.cc
+++ b/tests/p2pcommunicator_test.cc
@@ -145,13 +145,16 @@ void testCommunicator( const bool output )
     }
   }
 
-  // use handle to perform the same operations as above
-  DataHandle handle( comm, output );
-  comm.exchange( handle );
+  {
+    // use handle to perform the same operations as above
+    DataHandle handle( comm, output );
+    comm.exchange( handle );
+  }
 
   for( int i=0; i<5; ++i )
   {
     // use handle to perform the same operations as above
+    DataHandle handle( comm, output );
     comm.exchangeCached( handle );
   }
 }


### PR DESCRIPTION
Just silence a few warnings. Robert, could you check that the change to line 155 is what was intended in the first place?

I also noticed that this test does not use the same test framework (boost.test) as the others, but instead does `#undef NDEBUG` and uses `assert`. Is this made so on purpose, or did it just happen to be an old test we imported?