### PR TITLE
Point2PointCommunicator: fix bug due to invalid read position.

### DIFF
--- a/dune/grid/common/p2pcommunicator.hh
+++ b/dune/grid/common/p2pcommunicator.hh
@@ -82,6 +82,13 @@ public:
         buffer_.resize( size );
     }
 
+    /** \brief resize buffer to 'size' entries and reset read Position */
+    void resizeAndReset( const size_t size )
+    {
+        resize( size );
+        resetReadPosition();
+    }
+
     /** \brief write value to buffer, value must implement the operator= correctly (i.e. no internal pointers etc.) */
     template <class T>
     void write( const T& value )

--- a/dune/grid/common/p2pcommunicator_impl.hh
+++ b/dune/grid/common/p2pcommunicator_impl.hh
@@ -481,7 +481,7 @@ namespace Dune
                       MessageBufferType& msgBuffer, MPI_Request& request, MPI_Comm& comm )
     {
       // reserve memory for receive buffer
-      msgBuffer.resize( bufferSize );
+      msgBuffer.resizeAndReset( bufferSize );
 
       // get buffer and size
       std::pair< char*, int > buffer = msgBuffer.buffer();
@@ -557,7 +557,7 @@ namespace Dune
         }
 
         // reserve memory
-        osRecv.resize( bufferSize );
+        osRecv.resizeAndReset( bufferSize );
 
         // get buffer
         std::pair< char*, int > buffer = osRecv.buffer();

--- a/tests/p2pcommunicator_test.cc
+++ b/tests/p2pcommunicator_test.cc
@@ -70,7 +70,6 @@ public:
 
   void pack( const int link, MessageBufferType& buffer )
   {
-    assert( link == 0 && comm_.sendLinks() == 1 );
     int bsize = comm_.size() - comm_.rank();
     buffer.write( bsize );
     for( int r=comm_.rank(); r<comm_.size(); ++r )
@@ -79,7 +78,6 @@ public:
 
   void unpack( const int link, MessageBufferType& buffer )
   {
-    assert( link == 0 && comm_.recvLinks() == 1 );
     int bsize = -1;
     buffer.read( bsize );
     if( output_ )
@@ -109,6 +107,13 @@ void testCommunicator( const bool output )
   send.insert( rank < size-1 ? rank+1 : 0 );
   std::set<int> recv;
   recv.insert( rank > 0 ? rank-1 : size-1 );
+  if( rank > 0 )
+    send.insert( 0 );
+  if( rank == 0 )
+  {
+    for( int i=1; i<size; ++i )
+      recv.insert( i );
+  }
 
   comm.insertRequest( send, recv );
 


### PR DESCRIPTION
This PR fixed a bug when posting the MPI receive. Here, the buffers read position has to be reset in addition to resize. The test has been improved accordingly. 