### PR TITLE
Point2PointCommunicator: rename buffers and cleanup. 

### DIFF
--- a/dune/grid/common/p2pcommunicator.hh
+++ b/dune/grid/common/p2pcommunicator.hh
@@ -82,13 +82,6 @@ public:
         buffer_.resize( size );
     }
 
-    /** \brief resize buffer to 'size' entries and reset read Position */
-    void resizeAndReset( const size_t size )
-    {
-        resize( size );
-        resetReadPosition();
-    }
-
     /** \brief write value to buffer, value must implement the operator= correctly (i.e. no internal pointers etc.) */
     template <class T>
     void write( const T& value )


### PR DESCRIPTION
This PR removes an artefact and renames some of the buffer variables to have better meaning. 