### PR TITLE
make it compile on GCC 4.4

### DIFF
--- a/dune/grid/common/p2pcommunicator.hh
+++ b/dune/grid/common/p2pcommunicator.hh
@@ -52,7 +52,7 @@ namespace Dune
     typedef std::vector< char >  BufferType;
 
     mutable BufferType buffer_;
-    const double factor_;
+    double factor_;
     mutable size_t pos_;
 public:
     /** \brief constructor taking memory reserve estimation factor (default is 1.1, i.e. 10% over estimation )

--- a/tests/p2pcommunicator_test.cc
+++ b/tests/p2pcommunicator_test.cc
@@ -10,6 +10,7 @@
 #include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <iostream>
+#include <limits>
 
 void testBuffer()
 {
@@ -64,7 +65,7 @@ class DataHandle : public P2PCommunicatorType :: DataHandleInterface
   const P2PCommunicatorType& comm_;
   const bool output_ ;
 public:
-  typedef typename P2PCommunicatorType :: MessageBufferType MessageBufferType ;
+  typedef P2PCommunicatorType :: MessageBufferType MessageBufferType ;
   DataHandle( const P2PCommunicatorType& comm, const bool output )
     : comm_( comm ), output_( output ) {}
 
@@ -96,7 +97,7 @@ public:
 
 void testCommunicator( const bool output )
 {
-  typedef typename P2PCommunicatorType :: MessageBufferType MessageBufferType ;
+  typedef P2PCommunicatorType :: MessageBufferType MessageBufferType ;
 
   P2PCommunicatorType comm;
 

--- a/tests/polyhedralgrid_test.cc
+++ b/tests/polyhedralgrid_test.cc
@@ -39,6 +39,8 @@ const char *deckString =
 template <class GridView>
 void testGrid( const GridView& gridView )
 {
+// disable this function on GCC 4.4 because it causes an ICE
+#if !defined __GNUC__ || (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ > 4))
     typedef typename GridView::template Codim<0>::Iterator ElemIterator;
     typedef typename GridView::IntersectionIterator IsIt;
     typedef typename GridView::template Codim<0>::Geometry Geometry;
@@ -94,6 +96,7 @@ void testGrid( const GridView& gridView )
 
     if (numElem != 2*2*2)
         std::cout << "number of elements is wrong: " << numElem << "\n";
+#endif
 }
 
 int main()


### PR DESCRIPTION
again, the changes required to the actual library are pretty
trivial. the test function for the PolyhedralGrid is more interesting,
though: it causes an internal compiler error on GCC 4.4.