### PR TITLE
Make Dune::gridcheck compile with CpGrid. 

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -64,7 +64,7 @@ list (APPEND TEST_SOURCE_FILES
 	tests/cpgrid/orientedentitytable_test.cpp
 	tests/cpgrid/partition_iterator_test.cpp
 	tests/cpgrid/zoltan_test.cpp
-	tests/polyhedralgrid_test.cc
+	tests/grid_test.cc
 	tests/p2pcommunicator_test.cc
 	)
 

--- a/dune/grid/CpGrid.hpp
+++ b/dune/grid/CpGrid.hpp
@@ -574,7 +574,22 @@ namespace Dune
         /// \brief returns the number of boundary segments within the macro grid
         unsigned int numBoundarySegments() const
         {
-            return 0;
+            if( uniqueBoundaryIds() )
+            {
+                return current_view_data_->unique_boundary_ids_.size();
+            }
+            else
+            {
+                unsigned int numBndSegs = 0;
+                const int num_faces = numFaces();
+                for (int i = 0; i < num_faces; ++i) {
+                    cpgrid::EntityRep<1> face(i, true);
+                    if (current_view_data_->face_to_cell_[face].size() == 1) {
+                        ++numBndSegs;
+                    }
+                }
+                return numBndSegs;
+            }
         }
 
         // loadbalance is not part of the grid interface therefore we skip it.

--- a/dune/grid/CpGrid.hpp
+++ b/dune/grid/CpGrid.hpp
@@ -571,6 +571,12 @@ namespace Dune
             return 0;
         }
 
+        /// \brief returns the number of boundary segments within the macro grid
+        unsigned int numBoundarySegments() const
+        {
+            return 0;
+        }
+
         // loadbalance is not part of the grid interface therefore we skip it.
 
         /// \brief Distributes this grid over the available nodes in a distributed machine

--- a/dune/grid/CpGrid.hpp
+++ b/dune/grid/CpGrid.hpp
@@ -496,6 +496,13 @@ namespace Dune
           return leafIndexSet().geomTypes( codim );
         }
 
+        /// given an EntitySeed (or EntityPointer) return an entity object
+        template <int codim>
+        cpgrid::Entity<codim> entity( const cpgrid::EntityPointer< codim >& seed ) const
+        {
+            return cpgrid::Entity<codim>( *seed );
+        }
+
         /*  No refinement implemented. GridDefaultImplementation's methods will be used.
 
         /// \brief Mark entity for refinement

--- a/dune/grid/cpgrid/Entity.hpp
+++ b/dune/grid/cpgrid/Entity.hpp
@@ -274,10 +274,12 @@ namespace Dune
                 return *this;
             }
 
+            /// isValid method for EntitySeed
+            /// \return return true if seed is pointing to a valid entity
+            bool isValid () const;
+
         protected:
             const CpGridData* pgrid_;
-
-            bool valid() const;
         };
 
 
@@ -322,14 +324,14 @@ namespace Dune
             /// Const member by pointer operator.
             const Entity* operator->() const
             {
-                assert(Entity::valid());
+                assert(Entity::isValid());
                 return (this);
             }
 
             /// Const dereferencing operator.
             const Entity& operator*() const
             {
-                assert(Entity::valid());
+                assert(Entity::isValid());
                 return (*this);
             }
 
@@ -447,9 +449,9 @@ bool Entity<codim>::hasBoundaryIntersections() const
 }
 
 template <int codim>
-bool Entity<codim>::valid() const
+bool Entity<codim>::isValid() const
 {
-    return EntityRep<codim>::index() < pgrid_->size(codim);
+    return pgrid_ ? EntityRep<codim>::index() < pgrid_->size(codim) : false;
 }
 
 }}

--- a/dune/grid/cpgrid/Entity.hpp
+++ b/dune/grid/cpgrid/Entity.hpp
@@ -319,46 +319,18 @@ namespace Dune
             {
             }
 
-//          /// Member by pointer operator.
-//          Entity* operator->()
-//          {
-//              assert(Entity::valid());
-//              return this;
-//          }
-
-//          /// Const member by pointer operator.
-//          const Entity* operator->() const
-//          {
-//              assert(Entity::valid());
-//              return this;
-//          }
-
-//          /// Dereferencing operator.
-//          Entity& operator*()
-//          {
-//              assert(Entity::valid());
-//              return *this;
-//          }
-
-//          /// Const dereferencing operator.
-//          const Entity& operator*() const
-//          {
-//              assert(Entity::valid());
-//              return *this;
-//          }
-
             /// Const member by pointer operator.
             const Entity* operator->() const
             {
                 assert(Entity::valid());
-                return const_cast<EntityPointer*>(this); // const_cast-hack added because of error in vtkwriter.hh
+                return (this);
             }
 
             /// Const dereferencing operator.
             const Entity& operator*() const
             {
                 assert(Entity::valid());
-                return const_cast<EntityPointer&>(*this); // const_cast-hack added because of error in vtkwriter.hh
+                return (*this);
             }
 
 
@@ -370,8 +342,9 @@ namespace Dune
         };
     } // namespace cpgrid
 } // namespace Dune
-    // now we include the Iterators.hh We need to do this here because for hbegin/hend the compiler
-    // needs to know the size of hierarchicIterator
+
+// now we include the Iterators.hh We need to do this here because for hbegin/hend the compiler
+// needs to know the size of hierarchicIterator
 #include "Iterators.hpp"
 #include "Entity.hpp"
 #include "Intersection.hpp"

--- a/dune/grid/cpgrid/Entity.hpp
+++ b/dune/grid/cpgrid/Entity.hpp
@@ -75,7 +75,11 @@ namespace Dune
             enum { dimensionworld = 3 };
 
 
-            typedef EntityPointer<codim> EntityPointerType;
+            typedef cpgrid::EntityPointer<codim> EntityPointerType;
+
+            // the official DUNE names
+            typedef EntityPointerType    EntityPointer;
+            typedef EntityPointerType    EntitySeed;
 
             /// @brief
             /// @todo Doc me!
@@ -85,6 +89,7 @@ namespace Dune
             {
                 typedef cpgrid::EntityPointer<cd> EntityPointer;
             };
+
 
             typedef cpgrid::Geometry<3-codim,3> Geometry;
             typedef Geometry LocalGeometry;
@@ -103,6 +108,12 @@ namespace Dune
 //              : EntityRep<codim>(entityrep), pgrid_(&grid)
 //          {
 //          }
+
+            /// Constructor creating empty entity
+            Entity()
+                : EntityRep<codim>(), pgrid_( 0 )
+            {
+            }
 
             /// Constructor taking a grid and an entity representation.
             Entity(const CpGridData& grid, EntityRep<codim> entityrep)
@@ -130,9 +141,9 @@ namespace Dune
 
             /// Return an entity seed.
             /// For CpGrid, EntitySeed and EntityPtr are the same class.
-            EntityPointerType seed() const
+            EntitySeed seed() const
             {
-                return EntityPointerType(*this);
+                return EntitySeed( impl() );
             }
 
             /// Returns the geometry of the entity (does not depend on its orientation).
@@ -262,6 +273,7 @@ namespace Dune
             {
                 return *this;
             }
+
         protected:
             const CpGridData* pgrid_;
 
@@ -283,6 +295,11 @@ namespace Dune
         public:
             typedef cpgrid::Entity<codim> Entity;
             typedef const Entity& Reference;
+
+            /// Construction empty entity pointer
+            EntityPointer() : Entity()
+            {
+            }
 
             /// Construction from entity.
             explicit EntityPointer(const Entity& e)
@@ -331,14 +348,14 @@ namespace Dune
 //          }
 
             /// Const member by pointer operator.
-            Entity* operator->() const
+            const Entity* operator->() const
             {
                 assert(Entity::valid());
                 return const_cast<EntityPointer*>(this); // const_cast-hack added because of error in vtkwriter.hh
             }
 
             /// Const dereferencing operator.
-            Entity& operator*() const
+            const Entity& operator*() const
             {
                 assert(Entity::valid());
                 return const_cast<EntityPointer&>(*this); // const_cast-hack added because of error in vtkwriter.hh

--- a/dune/grid/cpgrid/Indexsets.hpp
+++ b/dune/grid/cpgrid/Indexsets.hpp
@@ -40,6 +40,8 @@ along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 #include <dune/geometry/type.hh>
 #include <opm/common/ErrorMacros.hpp>
 #include "GlobalIdMapping.hpp"
+#include "Intersection.hpp"
+
 namespace Dune
 {
     namespace cpgrid
@@ -201,6 +203,12 @@ namespace Dune
             IdType id(const EntityType& e) const
             {
                 return computeId(e);
+            }
+
+            /// return id of intersection (here face number)
+            IdType id( const cpgrid::Intersection& intersection ) const
+            {
+                return intersection.id();
             }
 
             template<int cc>

--- a/dune/grid/cpgrid/Intersection.hpp
+++ b/dune/grid/cpgrid/Intersection.hpp
@@ -237,6 +237,12 @@ namespace Dune
             /// @return
             FieldVector<ctype, 3> centerUnitOuterNormal() const;
 
+            int id() const
+            {
+                const EntityRep<1>& face = faces_of_cell_[subindex_];
+                return face.index();
+            }
+
         protected:
             const CpGridData* pgrid_;
             int index_;

--- a/dune/grid/cpgrid/Iterators.hpp
+++ b/dune/grid/cpgrid/Iterators.hpp
@@ -113,6 +113,32 @@ namespace Dune
     } // namespace cpgrid
 } // namespace Dune
 
+namespace std
+{
+  template< int codim, Dune::PartitionIteratorType pitype >
+  struct iterator_traits< Dune::cpgrid::Iterator< codim, pitype > >
+  {
+    typedef Dune::cpgrid::Iterator< codim, pitype > Iterator;
+    typedef ptrdiff_t difference_type;
+    typedef typename Iterator::Entity value_type;
+    typedef value_type *pointer;
+    typedef value_type &reference;
+    typedef forward_iterator_tag iterator_category;
+  };
+
+  template <>
+  struct iterator_traits< Dune::cpgrid::HierarchicIterator >
+  {
+    typedef ptrdiff_t difference_type;
+    typedef Dune::cpgrid::HierarchicIterator::Entity value_type;
+    typedef value_type *pointer;
+    typedef value_type &reference;
+    typedef forward_iterator_tag iterator_category;
+  };
+
+} // namespace std
+
+
 #include <dune/grid/cpgrid/CpGridData.hpp>
 #include "Entity.hpp"
 

--- a/dune/grid/cpgrid/Iterators.hpp
+++ b/dune/grid/cpgrid/Iterators.hpp
@@ -115,26 +115,26 @@ namespace Dune
 
 namespace std
 {
-  template< int codim, Dune::PartitionIteratorType pitype >
-  struct iterator_traits< Dune::cpgrid::Iterator< codim, pitype > >
-  {
-    typedef Dune::cpgrid::Iterator< codim, pitype > Iterator;
-    typedef ptrdiff_t difference_type;
-    typedef typename Iterator::Entity value_type;
-    typedef value_type *pointer;
-    typedef value_type &reference;
-    typedef forward_iterator_tag iterator_category;
-  };
+    template< int codim, Dune::PartitionIteratorType pitype >
+    struct iterator_traits< Dune::cpgrid::Iterator< codim, pitype > >
+    {
+        typedef Dune::cpgrid::Iterator< codim, pitype >     Iterator;
+        typedef ptrdiff_t                                   difference_type;
+        typedef typename Iterator::Entity                   value_type;
+        typedef value_type*                                 pointer;
+        typedef value_type&                                 reference;
+        typedef forward_iterator_tag                        iterator_category;
+    };
 
-  template <>
-  struct iterator_traits< Dune::cpgrid::HierarchicIterator >
-  {
-    typedef ptrdiff_t difference_type;
-    typedef Dune::cpgrid::HierarchicIterator::Entity value_type;
-    typedef value_type *pointer;
-    typedef value_type &reference;
-    typedef forward_iterator_tag iterator_category;
-  };
+    template <>
+    struct iterator_traits< Dune::cpgrid::HierarchicIterator >
+    {
+        typedef ptrdiff_t                                   difference_type;
+        typedef Dune::cpgrid::HierarchicIterator::Entity    value_type;
+        typedef value_type*                                 pointer;
+        typedef value_type&                                 reference;
+        typedef forward_iterator_tag                        iterator_category;
+    };
 
 } // namespace std
 

--- a/dune/grid/polyhedralgrid/idset.hh
+++ b/dune/grid/polyhedralgrid/idset.hh
@@ -55,6 +55,13 @@ namespace Dune
       return id< Entity::codimension >( entity );
     }
 
+    //! id method of all entities
+    template< class IntersectionImpl >
+    IdType id ( const Dune::Intersection< const Grid, IntersectionImpl >& intersection ) const
+    {
+      return Grid::getRealImplementation( intersection ).id();
+    }
+
     //! subId method for entities
     template< class Entity >
     IdType subId ( const Entity &entity, int i, unsigned int codim ) const

--- a/dune/grid/polyhedralgrid/intersection.hh
+++ b/dune/grid/polyhedralgrid/intersection.hh
@@ -168,6 +168,13 @@ namespace Dune
       return seed_.equals(other.seed_) && intersectionIdx_ == other.intersectionIdx_;
     }
 
+    // intersection id (here index of the face in the grid)
+    int id() const
+    {
+      // return face number of current intersection
+      return data()->template subEntitySeed<1>( seed_, intersectionIdx_).index();
+    }
+
   protected:
     ExtraData  data_;
     EntitySeed seed_;

--- a/tests/grid_test.cc
+++ b/tests/grid_test.cc
@@ -43,6 +43,9 @@ void testGridIteration( const GridView& gridView )
     typedef typename GridView::template Codim<0>::Iterator ElemIterator;
     typedef typename GridView::IntersectionIterator IsIt;
     typedef typename GridView::template Codim<0>::Geometry Geometry;
+    typedef typename GridView::Grid::LocalIdSet LocalIdSet;
+
+    const LocalIdSet& localIdSet = gridView.grid().localIdSet();
 
     int numElem = 0;
     ElemIterator elemIt = gridView.template begin<0>();
@@ -68,6 +71,7 @@ void testGridIteration( const GridView& gridView )
         {
             const auto& intersection = *isIt;
             const auto& isGeom = intersection.geometry();
+            std::cout << "Checking intersection id = " << localIdSet.id( intersection ) << std::endl;
             if (std::abs(isGeom.volume() - 1.0) > 1e-8)
                 std::cout << "volume of intersection " << numIs << " of element " << numElem << " volume is wrong: " << isGeom.volume() << "\n";
 


### PR DESCRIPTION
I have updated CpGrid to comply with the interface changes that were made in Dune 2.4.
