### PR TITLE
PolyhedralGrid: remove unused header.

### DIFF
--- a/dune/grid/polyhedralgrid/entity.hh
+++ b/dune/grid/polyhedralgrid/entity.hh
@@ -4,7 +4,6 @@
 #define DUNE_POLYHEDRALGRID_ENTITY_HH
 
 //- dune-common includes
-#include <dune/common/nullptr.hh>
 #include <dune/common/typetraits.hh>
 
 //- dune-grid includes

--- a/dune/grid/polyhedralgrid/grid.hh
+++ b/dune/grid/polyhedralgrid/grid.hh
@@ -12,7 +12,6 @@
 //- dune-common includes
 #include <dune/common/version.hh>
 #include <dune/common/array.hh>
-#include <dune/common/nullptr.hh>
 
 //- dune-grid includes
 #include <dune/grid/common/grid.hh>
@@ -323,7 +322,7 @@ namespace Dune
      *  \param[in]  ug    UnstructuredGrid reference
      */
     explicit PolyhedralGrid ( const UnstructuredGridType& grid )
-    : gridPtr_( 0 ),
+    : gridPtr_(),
       grid_( grid ),
       comm_( *this ),
       leafIndexSet_( *this ),

--- a/dune/grid/polyhedralgrid/idset.hh
+++ b/dune/grid/polyhedralgrid/idset.hh
@@ -3,7 +3,6 @@
 #ifndef DUNE_POLYHEDRALGRID_IDSET_HH
 #define DUNE_POLYHEDRALGRID_IDSET_HH
 
-#include <dune/common/nullptr.hh>
 #include <dune/grid/common/indexidset.hh>
 
 namespace Dune

--- a/dune/grid/polyhedralgrid/indexset.hh
+++ b/dune/grid/polyhedralgrid/indexset.hh
@@ -5,7 +5,6 @@
 
 #include <vector>
 
-#include <dune/common/nullptr.hh>
 #include <dune/common/typetraits.hh>
 
 #include <dune/grid/common/gridenums.hh>

--- a/dune/grid/polyhedralgrid/intersection.hh
+++ b/dune/grid/polyhedralgrid/intersection.hh
@@ -4,7 +4,6 @@
 #define DUNE_POLYHEDRALGRID_INTERSECTION_HH
 
 //- dune-common includes
-#include <dune/common/nullptr.hh>
 #include <dune/common/version.hh>
 
 //- local includes


### PR DESCRIPTION
This PR simply removes an unused header and fixes a small problem in one of the PolyhedralGrid constructors.