### PR TITLE
Bump version and unify format of dune.module.

### DIFF
--- a/dune.module
+++ b/dune.module
@@ -1,13 +1,15 @@
-#dune module information file#
-##############################
+####################################################################
+# Dune module information file: This file gets parsed by dunecontrol
+# and by the CMake build scripts.
+####################################################################
 
-#Name of the module
 Module: dune-cornerpoint
 Description: DUNE module supporting grids in a corner-point format
-Version: 1.1
-Label: 2013.10
+Version: 2016.04-pre
+Label: 2016.04-pre
 Maintainer: atgeirr@sintef.no
-#depending on 
+MaintainerName: Atgeirr F. Rasmussen
+Url: http://opm-project.org
 Depends: opm-common opm-core dune-common dune-grid
 Suggests: parallelgrid 
 Extra-Suggests: Alu3d

--- a/dune.module
+++ b/dune.module
@@ -11,5 +11,3 @@ Maintainer: atgeirr@sintef.no
 MaintainerName: Atgeirr F. Rasmussen
 Url: http://opm-project.org
 Depends: opm-common opm-core dune-common dune-grid
-Suggests: parallelgrid 
-Extra-Suggests: Alu3d


### PR DESCRIPTION
After this, all code modules have the same formatting in dune.module, and the correct version name (for the master branch): "2016.04-pre".