### PR TITLE
This completes the transition of identifying overlap cells with copy …

### DIFF
--- a/dune/grid/cpgrid/CpGridData.cpp
+++ b/dune/grid/cpgrid/CpGridData.cpp
@@ -646,7 +646,7 @@ void CpGridData::distributeGlobalGrid(const CpGrid& grid,
                 {
                     std::map<int,Modifier>::iterator mod=modifiers.find(*iter);
                     assert(mod!=modifiers.end());
-                    mod->second.insert(RemoteIndex(AttributeSet::overlap,&(*i)));
+                    mod->second.insert(RemoteIndex(AttributeSet::copy, &(*i)));
                 }
                 SIter end2=overlap[i->global()].end();
                 if(mine!=end2)
@@ -654,7 +654,7 @@ void CpGridData::distributeGlobalGrid(const CpGrid& grid,
                     {
                         std::map<int,Modifier>::iterator mod=modifiers.find(*mine);
                         assert(mod!=modifiers.end());
-                        mod->second.insert(RemoteIndex(AttributeSet::overlap,&(*i)));
+                        mod->second.insert(RemoteIndex(AttributeSet::copy, &(*i)));
                     }
             }
         }
@@ -940,10 +940,10 @@ void CpGridData::distributeGlobalGrid(const CpGrid& grid,
         .build(cell_remote_indices_, EnumItem<AttributeSet, AttributeSet::owner>(),
                AllSet<AttributeSet>());
     get<Overlap_OverlapFront_Interface>(cell_interfaces_)
-        .build(cell_remote_indices_, EnumItem<AttributeSet, AttributeSet::overlap>(),
-               EnumItem<AttributeSet, AttributeSet::overlap>());
+        .build(cell_remote_indices_, EnumItem<AttributeSet, AttributeSet::copy>(),
+               EnumItem<AttributeSet, AttributeSet::copy>());
     get<Overlap_All_Interface>(cell_interfaces_)
-        .build(cell_remote_indices_, EnumItem<AttributeSet, AttributeSet::overlap>(),
+        .build(cell_remote_indices_, EnumItem<AttributeSet, AttributeSet::copy>(),
                                  AllSet<AttributeSet>());
     get<All_All_Interface>(cell_interfaces_)
         .build(cell_remote_indices_, AllSet<AttributeSet>(), AllSet<AttributeSet>());


### PR DESCRIPTION
…indices in dune-istl.

It was needed for the parallel AMG to behave as expected when
agglomerating data to fewer processes. In this case the overlap in the
dune-grid sense has to marked as copy in the dune-istl index sets.
This was already done for the index sets, but the manually crafted
remote index list unsed in CpGrid did not reflect the change and
still marked cells not interrior as overlap and not copy. While this
was not a problem for the communication within the grid interface, it
broke the communication within dune-istl. The latter is used in
opm-autodiff and opm-core and there is poses a serious problem.

This commit fixes the setup of the remote index lists.