### PR TITLE
Add Dune::MPIHelper::instance() at start of main().

### DIFF
--- a/examples/grdecl2vtu.cpp
+++ b/examples/grdecl2vtu.cpp
@@ -113,6 +113,7 @@ void condWriteIntegerField(std::vector<double> & fieldvector,
 int main(int argc, char** argv)
 try
 {
+    Dune::MPIHelper::instance(argc,argv); // Dummy if no MPI.
 
     CpGrid grid;
 


### PR DESCRIPTION
Since the CpGrid class makes MPI calls if HAVE_MPI is set, we must ensure that MPI is initialised. The MPIHelper can be used unconditionally since it will be a dummy without MPI (at least I think that is correct).