### PR TITLE
Honor transmissibilities when loadbalancing as edge weights

### DIFF
--- a/dune/grid/CpGrid.hpp
+++ b/dune/grid/CpGrid.hpp
@@ -605,9 +605,10 @@ namespace Dune
         /// \param The number of layers of cells of the overlap region (default: 1).
         /// \warning May only be called once.
         bool loadBalance(Opm::EclipseStateConstPtr ecl=Opm::EclipseStateConstPtr(),
+                         const double* transmissibilities = nullptr,
                          int overlapLayers=1)
         {
-            return scatterGrid(ecl, overlapLayers);
+            return scatterGrid(ecl, transmissibilities, overlapLayers);
         }
 
         /// \brief Distributes this grid and data over the available nodes in a distributed machine.
@@ -626,9 +627,10 @@ namespace Dune
         template<class DataHandle>
         bool loadBalance(DataHandle& data,
                          Opm::EclipseStateConstPtr ecl=Opm::EclipseStateConstPtr(),
+                         const double* transmissibilities = nullptr,
                          int overlapLayers=1)
         {
-            bool ret = scatterGrid(ecl, overlapLayers);
+            bool ret = scatterGrid(ecl, transmissibilities, overlapLayers);
             scatterData(data);
             return ret;
         }
@@ -1118,7 +1120,8 @@ namespace Dune
         ///            of each well are stored on one process. This done by
         ///            adding an edge with a very high edge weight for all
         ///            possible pairs of cells in the completion set of a well.
-        bool scatterGrid(Opm::EclipseStateConstPtr ecl, int overlapLayers);
+        bool scatterGrid(Opm::EclipseStateConstPtr ecl, const double* transmissibilities,
+                         int overlapLayers);
 
         /** @brief The data stored in the grid.
          *

--- a/dune/grid/common/ZoltanGraphFunctions.cpp
+++ b/dune/grid/common/ZoltanGraphFunctions.cpp
@@ -286,7 +286,7 @@ void getCpGridWellsEdgeList(void *graphPointer, int sizeGID, int sizeLID,
                     if ( wellEdges.find(otherCell) == wellEdges.end() )
                     {
                         nborGID[idx] = globalID[otherCell];
-                        ewgts[idx++] = 1;
+                        ewgts[idx++] = graph.transmissibility(face);
                     }
                     continue;
                 }
@@ -294,7 +294,7 @@ void getCpGridWellsEdgeList(void *graphPointer, int sizeGID, int sizeLID,
             if ( wellEdges.find(otherCell) == wellEdges.end() )
             {
                 nborGID[idx] = globalID[otherCell];
-                ewgts[idx++] = 1;
+                ewgts[idx++] = graph.transmissibility(face);
             }
         }
 #ifndef NDEBUG
@@ -328,8 +328,9 @@ void getCpGridWellsEdgeList(void *graphPointer, int sizeGID, int sizeLID,
 
 CombinedGridWellGraph::CombinedGridWellGraph(const CpGrid& grid,
                                              const Opm::EclipseStateConstPtr eclipseState,
+                                             const double* transmissibilities,
                                              bool pretendEmptyGrid)
-    : grid_(grid), eclipseState_(eclipseState)
+    : grid_(grid), eclipseState_(eclipseState), transmissibilities_(transmissibilities)
 {
     if ( pretendEmptyGrid )
     {

--- a/dune/grid/common/ZoltanGraphFunctions.hpp
+++ b/dune/grid/common/ZoltanGraphFunctions.hpp
@@ -129,6 +129,7 @@ public:
     /// \param pretendEmptyGrid True if we should pretend the grid and wells are empty.
     CombinedGridWellGraph(const Dune::CpGrid& grid,
                           Opm::EclipseStateConstPtr eclipseState,
+                          const double* transmissibilities,
                           bool pretendEmptyGrid);
 
     /// \brief Access the grid.
@@ -144,7 +145,11 @@ public:
     /// \brief Post process partitioning to ensure a well is completely on one process.
     /// \param[inout] parts The assigned partition numbers for each vertex.
     void postProcessPartitioningForWells(std::vector<int>& parts);
-    
+
+    double transmissibility(int face_index) const
+    {
+        return transmissibilities_ ? (1.0e18*transmissibilities_[face_index]) : 1;
+    }
 private:
     void addCompletionSetToGraph(std::set<int>& well_indices)
     {
@@ -166,6 +171,7 @@ private:
     const Dune::CpGrid& grid_;
     Opm::EclipseStateConstPtr eclipseState_;
     GraphType wellsGraph_;
+    const double* transmissibilities_;
 };
 
 

--- a/dune/grid/common/ZoltanPartition.cpp
+++ b/dune/grid/common/ZoltanPartition.cpp
@@ -28,6 +28,7 @@ namespace cpgrid
 {
 std::vector<int> zoltanGraphPartitionGridOnRoot(const CpGrid& cpgrid,
                                                 const Opm::EclipseStateConstPtr eclipseState,
+                                                const double* transmissibilities,
                                                 const CollectiveCommunication<MPI_Comm>& cc,
                                                 int root)
 {
@@ -64,7 +65,8 @@ std::vector<int> zoltanGraphPartitionGridOnRoot(const CpGrid& cpgrid,
     if( eclipseState )
     {
         Zoltan_Set_Param(zz,"EDGE_WEIGHT_DIM","1");
-        grid_and_wells.reset(new CombinedGridWellGraph(cpgrid, eclipseState, pretendEmptyGrid));
+        grid_and_wells.reset(new CombinedGridWellGraph(cpgrid, eclipseState,
+                                                       transmissibilities, pretendEmptyGrid));
         Dune::cpgrid::setCpGridZoltanGraphFunctions(zz, *grid_and_wells,
                                                     pretendEmptyGrid);
     }

--- a/dune/grid/common/ZoltanPartition.hpp
+++ b/dune/grid/common/ZoltanPartition.hpp
@@ -45,6 +45,7 @@ namespace cpgrid
 ///         the number of the process that owns it after repartitioning.
 std::vector<int> zoltanGraphPartitionGridOnRoot(const CpGrid& grid,
                                                 const Opm::EclipseStateConstPtr eclipseState,
+                                                const double* transmissibilities,
                                                 const CollectiveCommunication<MPI_Comm>& cc,
                                                 int root);
 }

--- a/dune/grid/cpgrid/CpGrid.cpp
+++ b/dune/grid/cpgrid/CpGrid.cpp
@@ -91,7 +91,8 @@ namespace Dune
     }
 
 
-bool CpGrid::scatterGrid(Opm::EclipseStateConstPtr ecl, int overlapLayers)
+bool CpGrid::scatterGrid(Opm::EclipseStateConstPtr ecl,
+                         const double* transmissibilities, int overlapLayers)
 {
     // Silence any unused argument warnings that could occur with various configurations.
     static_cast<void>(ecl);
@@ -109,7 +110,8 @@ bool CpGrid::scatterGrid(Opm::EclipseStateConstPtr ecl, int overlapLayers)
     std::vector<int> cell_part(current_view_data_->global_cell_.size());
     int my_num=cc.rank();
 #ifdef HAVE_ZOLTAN
-    cell_part = cpgrid::zoltanGraphPartitionGridOnRoot(*this, ecl, cc, 0);
+    cell_part = cpgrid::zoltanGraphPartitionGridOnRoot(*this, ecl, transmissibilities,
+                                                       cc, 0);
     int num_parts = cc.size();
 #else
     int  num_parts=-1;


### PR DESCRIPTION
It tells Zoltan to cut at faces with low transmissibilities rather than with high ones. For the latter we expect that the is better for the linear solvers to have them in one subdomain.

Note that this PR is mainly for information purposes and for people that want to try out the parallel version of flow (PR upcoming).
In the long run it might to turn out that we must change the weights. Neverthless this PR in itself is harmless and does not change sequential runs.