### PR TITLE
Missing headers in Zoltan configuration

### DIFF
--- a/dune/grid/common/ZoltanGraphFunctions.cpp
+++ b/dune/grid/common/ZoltanGraphFunctions.cpp
@@ -22,10 +22,15 @@
 #include <config.h>
 #endif
 #include <limits>
+#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/CompletionSet.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well.hpp>
 #include <dune/grid/common/ZoltanGraphFunctions.hpp>
 #include <dune/common/parallel/indexset.hh>
 #if defined(HAVE_ZOLTAN) && defined(HAVE_MPI)
+#include <opm/parser/eclipse/EclipseState/Schedule/Well.hpp>
 namespace Dune
 {
 namespace cpgrid

--- a/dune/grid/common/ZoltanPartition.cpp
+++ b/dune/grid/common/ZoltanPartition.cpp
@@ -21,6 +21,7 @@
 #include <config.h>
 #endif
 #include <dune/grid/common/ZoltanPartition.hpp>
+#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #if defined(HAVE_ZOLTAN) && defined(HAVE_MPI)
 namespace Dune
 {


### PR DESCRIPTION
Includes necessary after opm-parser#661 added.