### PR TITLE
PolyhedralGrid: Add default constructor for Entities.

### DIFF
--- a/dune/grid/polyhedralgrid/entity.hh
+++ b/dune/grid/polyhedralgrid/entity.hh
@@ -163,11 +163,11 @@ namespace Dune
     typedef typename Base :: EntitySeed EntitySeed;
     using Base :: codimension ;
 
-    explicit PolyhedralGridEntity ()
+    PolyhedralGridEntity ()
     : Base()
     {}
 
-    PolyhedralGridEntity ( ExtraData data )
+    explicit PolyhedralGridEntity ( ExtraData data )
     : Base( data )
     {}
 

--- a/dune/grid/polyhedralgrid/entity.hh
+++ b/dune/grid/polyhedralgrid/entity.hh
@@ -68,6 +68,12 @@ namespace Dune
      *  \{ */
 
     /** \brief construct a null entity */
+    PolyhedralGridEntityBasic ()
+    : data_( nullptr ),
+      seed_()
+    {}
+
+    /** \brief construct a null entity with data pointer */
     explicit PolyhedralGridEntityBasic ( ExtraData data )
     : data_( data ),
       seed_()
@@ -157,7 +163,11 @@ namespace Dune
     typedef typename Base :: EntitySeed EntitySeed;
     using Base :: codimension ;
 
-    explicit PolyhedralGridEntity ( ExtraData data )
+    explicit PolyhedralGridEntity ()
+    : Base()
+    {}
+
+    PolyhedralGridEntity ( ExtraData data )
     : Base( data )
     {}
 
@@ -221,6 +231,11 @@ namespace Dune
      *  \{ */
 
     /** \brief construct a null entity */
+    PolyhedralGridEntity ()
+    : Base()
+    {}
+
+    /** \brief construct a null entity with data pointer */
     explicit PolyhedralGridEntity ( ExtraData data )
     : Base( data )
     {}

--- a/dune/grid/polyhedralgrid/grid.hh
+++ b/dune/grid/polyhedralgrid/grid.hh
@@ -916,7 +916,7 @@ namespace Dune
       }
     }
 
-    const std::vector< GeometryType > &geomTypes ( int codim ) const
+    const std::vector< GeometryType > &geomTypes ( const unsigned int codim ) const
     {
       static std::vector< GeometryType > emptyDummy;
       if (0 <= codim && codim < geomTypes_.size())


### PR DESCRIPTION
This is needed to compile with DUNE >= 2.4. Surprising that this has not been discovered earlier.