### PR TITLE
Change Deck access methods/types to references

### DIFF
--- a/examples/grdecl2vtu.cpp
+++ b/examples/grdecl2vtu.cpp
@@ -63,7 +63,7 @@ void condWriteDoubleField(std::vector<double> & fieldvector,
                           VTKWriter<CpGrid::LeafGridView> & vtkwriter) {
     if (deck->hasKeyword(fieldname)) {
         std::cout << "Found " << fieldname << "..." << std::endl;
-        std::vector<double> eclVector = deck->getKeyword(fieldname)->getRawDoubleData();
+        std::vector<double> eclVector = deck->getKeyword(fieldname).getRawDoubleData();
         fieldvector.resize(global_cell.size());
 
         Opm::EclipseGridInspector insp(deck);
@@ -90,7 +90,7 @@ void condWriteIntegerField(std::vector<double> & fieldvector,
                            VTKWriter<CpGrid::LeafGridView> & vtkwriter) {
     if (deck->hasKeyword(fieldname)) {
         std::cout << "Found " << fieldname << "..." << std::endl;
-        std::vector<int> eclVector = deck->getKeyword(fieldname)->getIntData();
+        std::vector<int> eclVector = deck->getKeyword(fieldname).getIntData();
         fieldvector.resize(global_cell.size());
 
         Opm::EclipseGridInspector insp(deck);


### PR DESCRIPTION
OPM/opm-parser#677 changes the return types for the Deck family of classes.
This patch fixes all broken code from that patch set.

https://github.com/OPM/opm-parser/pull/677