### PR TITLE
Fixes needed before opm output change

### DIFF
--- a/dune/grid/cpgrid/readEclipseFormat.cpp
+++ b/dune/grid/cpgrid/readEclipseFormat.cpp
@@ -40,7 +40,6 @@
 
 #include "CpGridData.hpp"
 
-#include <opm/core/io/eclipse/EclipseGridInspector.hpp>
 #include <opm/core/grid/cpgpreprocess/preprocess.h>
 #include <opm/core/grid/MinpvProcessor.hpp>
 #include <dune/grid/common/GeometryHelpers.hpp>


### PR DESCRIPTION
Mostly avoiding the EclipseGridInspector, so that we don't have to make this module depend on opm-output.